### PR TITLE
feat: CLI scaffolding (npx my-crud-lib init)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ BCRYPT_SALT="10"
 
 `JWT_ACCESS_EXPIRES_IN` and `JWT_REFRESH_EXPIRES_IN` have defaults. `JWT_SECRET` and `DATABASE_URL` must be set before using the default auth and Prisma paths.
 
+## CLI Scaffolding
+
+Generate a starter Prisma schema, `.env`, and Express server in the current directory:
+
+```bash
+npx my-crud-lib init
+```
+
+This creates `prisma/schema.prisma`, `src/server.ts`, and `.env` (skipping any that already exist). Edit `.env` with your `DATABASE_URL` and `JWT_SECRET`, then follow the printed next steps to install dependencies and run the server.
+
 ## Quickstart With Express And Prisma
 
 ```ts

--- a/bin/init.mjs
+++ b/bin/init.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+import { existsSync, mkdirSync, copyFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const packageRoot = path.resolve(fileURLToPath(import.meta.url), '..', '..');
+const templateRoot = path.join(packageRoot, 'templates', 'init');
+const cwd = process.cwd();
+
+const files = [
+  { from: path.join(templateRoot, 'prisma', 'schema.prisma'), to: path.join(cwd, 'prisma', 'schema.prisma') },
+  { from: path.join(templateRoot, 'src', 'server.ts'), to: path.join(cwd, 'src', 'server.ts') },
+  { from: path.join(templateRoot, 'env.example'), to: path.join(cwd, '.env') },
+];
+
+function copyTemplate({ from, to }) {
+  if (existsSync(to)) {
+    console.log(`skip  ${path.relative(cwd, to)} (already exists)`);
+    return;
+  }
+  mkdirSync(path.dirname(to), { recursive: true });
+  copyFileSync(from, to);
+  console.log(`create ${path.relative(cwd, to)}`);
+}
+
+console.log('Scaffolding my-crud-lib project...\n');
+for (const file of files) copyTemplate(file);
+
+console.log(`
+Next steps:
+  npm i my-crud-lib express cors body-parser @prisma/client prisma dotenv
+  npx prisma generate
+  npx prisma migrate dev --name init
+  npx ts-node src/server.ts
+
+Edit .env with your DATABASE_URL and JWT_SECRET before starting the server.
+`);

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   "sideEffects": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "bin": {
+    "my-crud-lib": "bin/init.mjs"
+  },
   "keywords": [
     "auth",
     "authentication",
@@ -62,6 +65,8 @@
     "dist",
     "docs",
     "examples",
+    "bin",
+    "templates",
     "CHANGELOG.md",
     "README.md",
     "RELEASE.md",

--- a/templates/init/env.example
+++ b/templates/init/env.example
@@ -1,0 +1,6 @@
+DATABASE_URL="postgresql://app:app@localhost:5432/mycrud"
+JWT_SECRET="replace-with-a-long-random-secret"
+JWT_ACCESS_EXPIRES_IN="15m"
+JWT_REFRESH_EXPIRES_IN="7d"
+BCRYPT_SALT="10"
+PORT="3000"

--- a/templates/init/prisma/schema.prisma
+++ b/templates/init/prisma/schema.prisma
@@ -1,0 +1,93 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id                      Int                      @id @default(autoincrement())
+  email                   String                   @unique
+  passwordHash            String
+  name                    String?
+  role                    Role                     @default(USER)
+  emailVerifiedAt         DateTime?
+  createdAt               DateTime                 @default(now())
+  updatedAt               DateTime                 @updatedAt
+  profile                 Profile?
+  refreshTokens           RefreshToken[]
+  passwordResetTokens     PasswordResetToken[]
+  emailVerificationTokens EmailVerificationToken[]
+  oauthAccounts           OauthAccount[]
+}
+
+model Profile {
+  id        Int     @id @default(autoincrement())
+  userId    Int     @unique
+  bio       String?
+  avatarUrl String?
+  user      User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model RefreshToken {
+  id                String    @id
+  userId            Int
+  tokenHash         String
+  familyId          String
+  expiresAt         DateTime
+  revokedAt         DateTime?
+  replacedByTokenId String?
+  createdAt         DateTime  @default(now())
+  user              User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([familyId])
+}
+
+model PasswordResetToken {
+  id        String    @id
+  userId    Int
+  tokenHash String
+  expiresAt DateTime
+  usedAt    DateTime?
+  revokedAt DateTime?
+  createdAt DateTime  @default(now())
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+}
+
+model EmailVerificationToken {
+  id        String    @id
+  userId    Int
+  tokenHash String
+  expiresAt DateTime
+  usedAt    DateTime?
+  revokedAt DateTime?
+  createdAt DateTime  @default(now())
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+}
+
+model OauthAccount {
+  id                Int      @id @default(autoincrement())
+  provider          String
+  providerAccountId String
+  userId            Int
+  email             String?
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
+  user              User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([provider, providerAccountId])
+  @@index([userId])
+  @@map("OAuthAccount")
+}
+
+enum Role {
+  USER
+  ADMIN
+}

--- a/templates/init/src/server.ts
+++ b/templates/init/src/server.ts
@@ -1,0 +1,25 @@
+import 'dotenv/config';
+import { PrismaClient } from '@prisma/client';
+import { createLibrary, createServer } from 'my-crud-lib';
+import { makePrismaUserRepo } from 'my-crud-lib/adapter-prisma';
+
+const prisma = new PrismaClient();
+const app = createServer();
+
+const lib = createLibrary(
+  {
+    routesPrefix: '/api',
+    auth: {
+      passwordHashRounds: Number(process.env.BCRYPT_SALT) || 10,
+    },
+  },
+  { userRepo: makePrismaUserRepo(prisma) },
+);
+
+app.use(lib.router);
+
+const port = Number(process.env.PORT) || 3000;
+
+app.listen(port, () => {
+  console.log(`API running on http://localhost:${port}`);
+});


### PR DESCRIPTION
Closes #19.

## Summary
- New `bin/init.mjs` CLI, exposed as `npx my-crud-lib init`
- Generates `prisma/schema.prisma`, `src/server.ts`, `.env` in the consumer's cwd from bundled templates (`templates/init/`)
- Skips files that already exist instead of overwriting
- README updated with a "CLI Scaffolding" section

## Test plan
- [x] `npm run build` passes
- [x] Ran `node bin/init.mjs` in an empty temp dir, verified generated files