### PR TITLE
feat: typed error classes and public error handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,37 @@ app.use(
 
 These dependencies are optional. Without them, the existing stateless refresh-token flow remains available and password reset, email verification, and OAuth methods report that they are not configured.
 
+## Error Responses
+
+Routes created by this library respond to errors with a consistent shape:
+
+```json
+{
+  "error": {
+    "code": "INVALID_CREDENTIALS",
+    "message": "Invalid credentials"
+  }
+}
+```
+
+Validation errors additionally include a `details` array with Zod issues.
+
+The typed error classes and helpers are available for your own routes:
+
+```ts
+import {
+  AppError,
+  EmailAlreadyExistsError,
+  errorHandler,
+  mapKnownError,
+  sendAppError,
+} from "my-crud-lib/errors";
+```
+
+- `errorHandler` is an Express error-handling middleware (`app.use(errorHandler)`) for routes outside this library that call the same services/repos and `next(err)` their failures.
+- `sendAppError(res, err)` writes the same JSON shape directly from a catch block.
+- `mapKnownError(err)` normalizes any thrown value (a plain `Error`, a Zod error, or an `AppError`) into an `AppError` with a stable `code` and `statusCode`.
+
 ## Build Checks
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -52,6 +52,10 @@
       "import": "./dist/middleware.js",
       "types": "./dist/middleware.d.ts"
     },
+    "./errors": {
+      "import": "./dist/errors.js",
+      "types": "./dist/errors.d.ts"
+    },
     "./adapter-prisma": {
       "import": "./dist/adapter-prisma.js",
       "types": "./dist/adapter-prisma.d.ts"

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,13 @@
+export {
+  AppError,
+  EmailAlreadyExistsError,
+  ForbiddenError,
+  InvalidCredentialsError,
+  NotConfiguredError,
+  TokenExpiredError,
+  UserNotFoundError,
+  ValidationError,
+  errorHandler,
+  mapKnownError,
+  sendAppError,
+} from './utils/errorHandler.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,19 @@ export {
 export { isAuth, type AuthRequest } from './middleware/isAuth.js';
 export { hasRole, isSelfOrAdmin } from './middleware/hasRole.js';
 export {
+  AppError,
+  EmailAlreadyExistsError,
+  ForbiddenError,
+  InvalidCredentialsError,
+  NotConfiguredError,
+  TokenExpiredError,
+  UserNotFoundError,
+  ValidationError,
+  errorHandler,
+  mapKnownError,
+  sendAppError,
+} from './utils/errorHandler.js';
+export {
   makePrismaEmailVerificationTokenRepo,
   makePrismaOAuthAccountRepo,
   makePrismaPasswordResetTokenRepo,

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,5 +1,6 @@
 import { Router, type Request, type Response } from 'express';
 import { isAuth, type AuthRequest } from '../../middleware/isAuth.js';
+import { sendAppError } from '../../utils/errorHandler.js';
 import {
   emailVerificationConfirmSchema,
   emailVerificationRequestSchema,
@@ -20,10 +21,8 @@ export function createAuthRouter(deps: AuthServiceDeps) {
       const data = registerSchema.parse(req.body);
       const result = await service.registerUser(data);
       return res.status(201).json(result);
-    } catch (err: any) {
-      if (err?.message === 'EMAIL_TAKEN') return res.status(409).json({ error: 'Email already registered' });
-      if (err?.issues) return res.status(400).json({ error: 'ValidationError', details: err.issues });
-      return res.status(500).json({ error: 'InternalError' });
+    } catch (err) {
+      return sendAppError(res, err);
     }
   });
 
@@ -32,34 +31,32 @@ export function createAuthRouter(deps: AuthServiceDeps) {
       const data = loginSchema.parse(req.body);
       const result = await service.loginUser(data);
       return res.json(result);
-    } catch (err: any) {
-      if (err?.message === 'INVALID_CREDENTIALS') return res.status(401).json({ error: 'Invalid credentials' });
-      if (err?.issues) return res.status(400).json({ error: 'ValidationError', details: err.issues });
-      return res.status(500).json({ error: 'InternalError' });
+    } catch (err) {
+      return sendAppError(res, err);
     }
   });
 
   router.post('/refresh', async (req: Request, res: Response) => {
     try {
       const { refreshToken } = req.body as { refreshToken?: string };
-      if (!refreshToken) return res.status(400).json({ error: 'Missing refreshToken' });
+      if (!refreshToken) return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'Missing refreshToken' } });
 
       const tokens = await service.refreshSession(refreshToken);
       return res.json(tokens);
     } catch {
-      return res.status(401).json({ error: 'Invalid or expired refresh token' });
+      return sendAppError(res, new Error('INVALID_REFRESH_TOKEN'));
     }
   });
 
   router.post('/logout', async (req: Request, res: Response) => {
     try {
       const { refreshToken } = req.body as { refreshToken?: string };
-      if (!refreshToken) return res.status(400).json({ error: 'Missing refreshToken' });
+      if (!refreshToken) return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'Missing refreshToken' } });
 
       await service.revokeRefreshToken(refreshToken);
       return res.status(204).send();
     } catch {
-      return res.status(401).json({ error: 'Invalid or expired refresh token' });
+      return sendAppError(res, new Error('INVALID_REFRESH_TOKEN'));
     }
   });
 
@@ -68,10 +65,8 @@ export function createAuthRouter(deps: AuthServiceDeps) {
       const data = passwordResetRequestSchema.parse(req.body);
       await service.requestPasswordReset(data);
       return res.status(202).json({ ok: true });
-    } catch (err: any) {
-      if (err?.message === 'PASSWORD_RESET_UNSUPPORTED') return res.status(501).json({ error: 'Password reset is not configured' });
-      if (err?.issues) return res.status(400).json({ error: 'ValidationError', details: err.issues });
-      return res.status(500).json({ error: 'InternalError' });
+    } catch (err) {
+      return sendAppError(res, err);
     }
   });
 
@@ -80,11 +75,8 @@ export function createAuthRouter(deps: AuthServiceDeps) {
       const data = passwordResetConfirmSchema.parse(req.body);
       await service.confirmPasswordReset(data);
       return res.json({ ok: true });
-    } catch (err: any) {
-      if (err?.message === 'PASSWORD_RESET_UNSUPPORTED') return res.status(501).json({ error: 'Password reset is not configured' });
-      if (err?.message === 'INVALID_PASSWORD_RESET_TOKEN') return res.status(400).json({ error: 'Invalid or expired password reset token' });
-      if (err?.issues) return res.status(400).json({ error: 'ValidationError', details: err.issues });
-      return res.status(500).json({ error: 'InternalError' });
+    } catch (err) {
+      return sendAppError(res, err);
     }
   });
 
@@ -93,10 +85,8 @@ export function createAuthRouter(deps: AuthServiceDeps) {
       const data = emailVerificationRequestSchema.parse(req.body);
       await service.requestEmailVerification(data);
       return res.status(202).json({ ok: true });
-    } catch (err: any) {
-      if (err?.message === 'EMAIL_VERIFICATION_UNSUPPORTED') return res.status(501).json({ error: 'Email verification is not configured' });
-      if (err?.issues) return res.status(400).json({ error: 'ValidationError', details: err.issues });
-      return res.status(500).json({ error: 'InternalError' });
+    } catch (err) {
+      return sendAppError(res, err);
     }
   });
 
@@ -105,18 +95,15 @@ export function createAuthRouter(deps: AuthServiceDeps) {
       const data = emailVerificationConfirmSchema.parse(req.body);
       const result = await service.confirmEmailVerification(data);
       return res.json(result);
-    } catch (err: any) {
-      if (err?.message === 'EMAIL_VERIFICATION_UNSUPPORTED') return res.status(501).json({ error: 'Email verification is not configured' });
-      if (err?.message === 'INVALID_EMAIL_VERIFICATION_TOKEN') return res.status(400).json({ error: 'Invalid or expired email verification token' });
-      if (err?.issues) return res.status(400).json({ error: 'ValidationError', details: err.issues });
-      return res.status(500).json({ error: 'InternalError' });
+    } catch (err) {
+      return sendAppError(res, err);
     }
   });
 
   router.get('/me', isAuth, async (req: AuthRequest, res: Response) => {
     const userId = req.user!.id;
     const me = await service.getMe(userId);
-    if (!me) return res.status(404).json({ error: 'User not found' });
+    if (!me) return sendAppError(res, new Error('USER_NOT_FOUND'));
     return res.json(me);
   });
 

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { isAuth, type AuthRequest } from '../../middleware/isAuth.js';
 import { hasRole, isSelfOrAdmin } from '../../middleware/hasRole.js';
+import { ForbiddenError, sendAppError } from '../../utils/errorHandler.js';
 import {
   listUsersQuerySchema,
   updateMeSchema,
@@ -19,15 +20,14 @@ export function createUserRouter(deps: { userRepo: UserRepo }) {
       const q = listUsersQuerySchema.parse(req.query);
       const data = await service.listUsers(q);
       res.json(data);
-    } catch (e: any) {
-      if (e?.issues) return res.status(400).json({ error: 'ValidationError', details: e.issues });
-      res.status(500).json({ error: 'InternalError' });
+    } catch (err) {
+      sendAppError(res, err);
     }
   });
 
   router.get('/me', isAuth, async (req: AuthRequest, res) => {
     const data = await service.getUserById(req.user!.id);
-    if (!data) return res.status(404).json({ error: 'User not found' });
+    if (!data) return sendAppError(res, new Error('USER_NOT_FOUND'));
     res.json(data);
   });
 
@@ -36,9 +36,8 @@ export function createUserRouter(deps: { userRepo: UserRepo }) {
       const body = updateMeSchema.parse(req.body);
       const data = await service.updateMe(req.user!.id, body);
       res.json(data);
-    } catch (e: any) {
-      if (e?.issues) return res.status(400).json({ error: 'ValidationError', details: e.issues });
-      res.status(500).json({ error: 'InternalError' });
+    } catch (err) {
+      sendAppError(res, err);
     }
   });
 
@@ -47,51 +46,48 @@ export function createUserRouter(deps: { userRepo: UserRepo }) {
       const body = adminCreateUserSchema.parse(req.body);
       const data = await service.adminCreateUser(body);
       res.status(201).json(data);
-    } catch (e: any) {
-      if (e?.message === 'EMAIL_TAKEN') return res.status(409).json({ error: 'Email already in use' });
-      if (e?.issues) return res.status(400).json({ error: 'ValidationError', details: e.issues });
-      res.status(500).json({ error: 'InternalError' });
+    } catch (err) {
+      sendAppError(res, err);
     }
   });
 
   router.get('/:id', isAuth, isSelfOrAdmin(), async (req: AuthRequest, res) => {
     const id = Number(req.params.id);
-    if (Number.isNaN(id)) return res.status(400).json({ error: 'Invalid id' });
+    if (Number.isNaN(id)) return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'Invalid id' } });
 
     const data = await service.getUserById(id);
-    if (!data) return res.status(404).json({ error: 'User not found' });
+    if (!data) return sendAppError(res, new Error('USER_NOT_FOUND'));
     res.json(data);
   });
 
   router.put('/:id', isAuth, isSelfOrAdmin(), async (req: AuthRequest, res) => {
     try {
       const id = Number(req.params.id);
-      if (Number.isNaN(id)) return res.status(400).json({ error: 'Invalid id' });
+      if (Number.isNaN(id)) return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'Invalid id' } });
 
       const body = adminUpdateUserSchema.parse(req.body);
 
       if (req.user!.role !== 'ADMIN' && body.role) {
-        return res.status(403).json({ error: 'Forbidden: cannot change role' });
+        return sendAppError(res, new ForbiddenError('Forbidden: cannot change role'));
       }
 
       const sanitizedBody = { ...body, role: body.role === null ? undefined : body.role };
       const data = await service.adminUpdateUser(id, sanitizedBody);
       res.json(data);
-    } catch (e: any) {
-      if (e?.issues) return res.status(400).json({ error: 'ValidationError', details: e.issues });
-      res.status(500).json({ error: 'InternalError' });
+    } catch (err) {
+      sendAppError(res, err);
     }
   });
 
   router.delete('/:id', isAuth, hasRole('ADMIN'), async (req, res) => {
     try {
       const id = Number(req.params.id);
-      if (Number.isNaN(id)) return res.status(400).json({ error: 'Invalid id' });
+      if (Number.isNaN(id)) return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'Invalid id' } });
 
       await service.adminDeleteUser(id);
       res.status(204).end();
-    } catch {
-      res.status(500).json({ error: 'InternalError' });
+    } catch (err) {
+      sendAppError(res, err);
     }
   });
 

--- a/src/utils/errorHandler.ts
+++ b/src/utils/errorHandler.ts
@@ -1,0 +1,106 @@
+import type { NextFunction, Request, Response } from 'express';
+
+export class AppError extends Error {
+  readonly code: string;
+  readonly statusCode: number;
+  readonly details?: unknown;
+
+  constructor(code: string, message: string, statusCode: number, details?: unknown) {
+    super(message);
+    this.name = 'AppError';
+    this.code = code;
+    this.statusCode = statusCode;
+    this.details = details;
+  }
+}
+
+export class EmailAlreadyExistsError extends AppError {
+  constructor(message = 'Email already registered') {
+    super('EMAIL_ALREADY_EXISTS', message, 409);
+  }
+}
+
+export class InvalidCredentialsError extends AppError {
+  constructor(message = 'Invalid credentials') {
+    super('INVALID_CREDENTIALS', message, 401);
+  }
+}
+
+export class UserNotFoundError extends AppError {
+  constructor(message = 'User not found') {
+    super('USER_NOT_FOUND', message, 404);
+  }
+}
+
+export class TokenExpiredError extends AppError {
+  constructor(message = 'Invalid or expired token') {
+    super('TOKEN_EXPIRED', message, 401);
+  }
+}
+
+export class ForbiddenError extends AppError {
+  constructor(message = 'Forbidden') {
+    super('FORBIDDEN', message, 403);
+  }
+}
+
+export class NotConfiguredError extends AppError {
+  constructor(message = 'This feature is not configured') {
+    super('NOT_CONFIGURED', message, 501);
+  }
+}
+
+export class ValidationError extends AppError {
+  constructor(details: unknown, message = 'Validation failed') {
+    super('VALIDATION_ERROR', message, 400, details);
+  }
+}
+
+const KNOWN_SERVICE_ERRORS: Record<string, () => AppError> = {
+  EMAIL_TAKEN: () => new EmailAlreadyExistsError(),
+  INVALID_CREDENTIALS: () => new InvalidCredentialsError(),
+  USER_NOT_FOUND: () => new UserNotFoundError(),
+  INVALID_REFRESH_TOKEN: () => new TokenExpiredError('Invalid or expired refresh token'),
+  REFRESH_TOKEN_REPLAYED: () => new TokenExpiredError('Invalid or expired refresh token'),
+  INVALID_PASSWORD_RESET_TOKEN: () => new TokenExpiredError('Invalid or expired password reset token'),
+  INVALID_EMAIL_VERIFICATION_TOKEN: () => new TokenExpiredError('Invalid or expired email verification token'),
+  PASSWORD_RESET_UNSUPPORTED: () => new NotConfiguredError('Password reset is not configured'),
+  EMAIL_VERIFICATION_UNSUPPORTED: () => new NotConfiguredError('Email verification is not configured'),
+  OAUTH_UNSUPPORTED: () => new NotConfiguredError('OAuth sign-in is not configured'),
+};
+
+/**
+ * Normalizes any thrown value (a service-layer Error, a ZodError, or an
+ * already-typed AppError) into a single AppError shape carrying a stable
+ * `code`, HTTP `statusCode`, and human-readable `message`.
+ */
+export function mapKnownError(err: unknown): AppError {
+  if (err instanceof AppError) return err;
+
+  if (err && typeof err === 'object' && 'issues' in err) {
+    return new ValidationError((err as { issues: unknown }).issues);
+  }
+
+  const message = err instanceof Error ? err.message : undefined;
+  const factory = message ? KNOWN_SERVICE_ERRORS[message] : undefined;
+  if (factory) return factory();
+
+  return new AppError('INTERNAL_ERROR', 'Internal server error', 500);
+}
+
+/** Writes a consistent `{ error: { code, message, details? } }` JSON response for an AppError. */
+export function sendAppError(res: Response, err: unknown): void {
+  const appError = mapKnownError(err);
+  res.status(appError.statusCode).json({
+    error: {
+      code: appError.code,
+      message: appError.message,
+      ...(appError.details !== undefined ? { details: appError.details } : {}),
+    },
+  });
+}
+
+/** Express error-handling middleware. Mount last with `app.use(errorHandler)`. */
+export function errorHandler(err: unknown, _req: Request, res: Response, _next: NextFunction): void {
+  sendAppError(res, err);
+}


### PR DESCRIPTION
Closes #20.

## Summary
- New `src/utils/errorHandler.ts`: `AppError` base class + typed subclasses (`EmailAlreadyExistsError`, `InvalidCredentialsError`, `UserNotFoundError`, `TokenExpiredError`, `ForbiddenError`, `NotConfiguredError`, `ValidationError`)
- `mapKnownError(err)` normalizes plain `Error`s (including the existing string-keyed service errors like `EMAIL_TAKEN`), Zod errors, and `AppError`s into one typed shape
- `sendAppError(res, err)` and `errorHandler` Express middleware for consistent JSON responses
- Exported from `my-crud-lib` and a new `my-crud-lib/errors` entry point
- Auth and user controllers now use `sendAppError` instead of ad hoc per-route status/JSON mapping

## Behavior change
Error response bodies change shape from `{ "error": "<string>" }` to `{ "error": { "code": "...", "message": "...", "details"?: [...] } }`. Status codes are unchanged. README updated with the new shape and usage.

## Test plan
- [x] `npm test` (14/14 passing — service-layer tests assert on thrown error messages, not HTTP shape, so unaffected)
- [x] `npm run smoke:exports`
- [x] `npm run smoke:auth-hardening`
- [x] `npm run smoke:auth-service`
- [x] `npm run build`