### PR TITLE
docs: JSDoc for public API

### DIFF
--- a/src/adapters/prisma.ts
+++ b/src/adapters/prisma.ts
@@ -10,6 +10,7 @@ import type { AdminUpdateUserInput, UserListItem } from '../modules/user/user.ty
 
 const dateOrNow = (value?: Date) => value ?? new Date();
 
+/** `UserRepo` implementation backed by the bundled Prisma schema (`prisma/schema.prisma`). */
 export function makePrismaUserRepo(prisma: PrismaClient): UserRepo {
   return {
     async count({ role, search }) {
@@ -181,6 +182,7 @@ export function makePrismaUserRepo(prisma: PrismaClient): UserRepo {
   };
 }
 
+/** `RefreshTokenRepo` implementation; pass it to `createAuthRouter` to enable persistent refresh token rotation/revocation. */
 export function makePrismaRefreshTokenRepo(prisma: PrismaClient): RefreshTokenRepo {
   return {
     create(input) {
@@ -210,6 +212,7 @@ export function makePrismaRefreshTokenRepo(prisma: PrismaClient): RefreshTokenRe
   };
 }
 
+/** `PasswordResetTokenRepo` implementation; pass it (with `sendPasswordReset`) to `createAuthRouter` to enable the password reset flow. */
 export function makePrismaPasswordResetTokenRepo(prisma: PrismaClient): PasswordResetTokenRepo {
   return {
     create(input) {
@@ -236,6 +239,7 @@ export function makePrismaPasswordResetTokenRepo(prisma: PrismaClient): Password
   };
 }
 
+/** `EmailVerificationTokenRepo` implementation; pass it (with `sendEmailVerification`) to `createAuthRouter` to enable the email verification flow. */
 export function makePrismaEmailVerificationTokenRepo(prisma: PrismaClient): EmailVerificationTokenRepo {
   return {
     create(input) {
@@ -262,6 +266,7 @@ export function makePrismaEmailVerificationTokenRepo(prisma: PrismaClient): Emai
   };
 }
 
+/** `OAuthAccountRepo` implementation; pass it to `createAuthRouter` to enable OAuth account linking. */
 export function makePrismaOAuthAccountRepo(prisma: PrismaClient): OAuthAccountRepo {
   return {
     findByProviderAccount(provider, providerAccountId) {

--- a/src/core/ports/user.repo.ts
+++ b/src/core/ports/user.repo.ts
@@ -1,7 +1,14 @@
 import type { AdminCreateUserInput, AdminUpdateUserInput, ListUsersQuery, UserListItem } from "../../modules/user/user.types.js";
 
+/**
+ * Storage port implemented by every adapter (Prisma, in-memory, or custom).
+ * `updatePassword` and `markEmailVerified` are optional; omitting them
+ * disables password reset and email verification respectively.
+ */
 export interface UserRepo {
+  /** Counts users matching the given filters, for pagination totals. */
   count(where: { role?: string; search?: string } ): Promise<number>;
+  /** Returns one page of users, sorted per `sortField`/`sortDir`. */
   findMany(params: {
     page: number;
     pageSize: number;
@@ -11,11 +18,15 @@ export interface UserRepo {
     sortDir: 'asc'|'desc';
   }): Promise<UserListItem[]>;
   findById(id: number | string): Promise<UserListItem | null>;
+  /** Must include `passwordHash` so the auth service can verify credentials. */
   findByEmail(email: string): Promise<UserListItem & { passwordHash?: string } | null>;
   create(input: { email: string; passwordHash: string; name?: string | null; role?: string; bio?: string | null; avatarUrl?: string | null }): Promise<UserListItem>;
   update(id: number | string, input: AdminUpdateUserInput): Promise<UserListItem>;
   delete(id: number | string): Promise<void>;
+  /** Self-service update, restricted to the profile fields a user may change on their own account. */
   updateMe(userId: number | string, input: { name?: string | null; bio?: string | null; avatarUrl?: string | null }): Promise<UserListItem>;
+  /** Required for the password reset flow; omit to leave it unsupported. */
   updatePassword?(id: number | string, passwordHash: string): Promise<UserListItem | void>;
+  /** Required for the email verification flow; omit to leave it unsupported. */
   markEmailVerified?(id: number | string, verifiedAt?: Date): Promise<UserListItem | void>;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,11 +78,15 @@ import type { AuthServiceDeps } from './modules/auth/auth.types.js';
 import { createAuthRouter } from './modules/auth/auth.controller.js';
 import { createUserRouter } from './modules/user/user.controller.js';
 
+/** Options for `createLibrary`/`mountDefaultRoutes`. */
 export type LibraryConfig = {
+  /** Prefix applied to all mounted routes, e.g. `/api`. */
   routesPrefix?: string;
+  /** Passed through to `createAuthRouter` alongside `deps.userRepo`. */
   auth?: Omit<AuthServiceDeps, 'userRepo'>;
 };
 
+/** Dependencies for `createLibrary`/`mountDefaultRoutes`. */
 export type LibraryDeps = {
   userRepo: UserRepo;
 };
@@ -95,6 +99,7 @@ function normalizePrefix(prefix?: string): string {
   return withLeadingSlash.endsWith('/') ? withLeadingSlash.slice(0, -1) : withLeadingSlash;
 }
 
+/** Creates an Express app with `cors` and JSON body parsing already wired in. */
 export function createServer(): Express {
   const app = express();
   app.use(cors());
@@ -102,6 +107,14 @@ export function createServer(): Express {
   return app;
 }
 
+/**
+ * Builds the combined auth + user router for this library.
+ *
+ * @param config.routesPrefix - Path prefix for all mounted routes, e.g. `/api`. Defaults to no prefix.
+ * @param config.auth - Extra `AuthServiceDeps` (excluding `userRepo`), e.g. `passwordHashRounds` or optional token repos.
+ * @param deps.userRepo - The `UserRepo` adapter backing both auth and user CRUD.
+ * @returns `{ router }` — mount it with `app.use(router)`.
+ */
 export function createLibrary(config: LibraryConfig, deps: LibraryDeps) {
   const router = Router();
   const prefix = normalizePrefix(config.routesPrefix);
@@ -112,6 +125,7 @@ export function createLibrary(config: LibraryConfig, deps: LibraryDeps) {
   return { router };
 }
 
+/** Convenience wrapper that builds the router via `createLibrary` and mounts it on `app` directly. */
 export function mountDefaultRoutes(app: Express, deps: LibraryDeps, config: LibraryConfig = {}) {
   const { router } = createLibrary(config, deps);
   app.use(router);

--- a/src/middleware/hasRole.ts
+++ b/src/middleware/hasRole.ts
@@ -1,6 +1,7 @@
 import { Response, NextFunction } from 'express';
 import { AuthRequest } from './isAuth.js';
 
+/** Requires `req.user.role` (set by `isAuth`) to be one of `allowed`; responds 403 otherwise. */
 export function hasRole(...allowed: Array<'ADMIN' | 'USER'>) {
   return (req: AuthRequest, res: Response, next: NextFunction) => {
     const role = req.user?.role;
@@ -11,6 +12,7 @@ export function hasRole(...allowed: Array<'ADMIN' | 'USER'>) {
   };
 }
 
+/** Allows the request through if `req.user` is an admin or owns the `:id` route param; responds 403 otherwise. */
 export function isSelfOrAdmin() {
   return (req: AuthRequest, res: Response, next: NextFunction) => {
     const uid = req.user?.id;

--- a/src/middleware/isAuth.ts
+++ b/src/middleware/isAuth.ts
@@ -3,6 +3,7 @@ import { verifyToken } from '../utils/jwt.js';
 
 export type AuthRequest = Request & { user?: { id: number | string; role: 'USER' | 'ADMIN' } };
 
+/** Verifies the `Authorization: Bearer <token>` header and attaches `req.user`. Responds 401 if missing/invalid. */
 export function isAuth(req: AuthRequest, res: Response, next: NextFunction) {
   const auth = req.headers.authorization;
   if (!auth?.startsWith('Bearer ')) {

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -12,6 +12,12 @@ import {
 import { makeAuthService } from './auth.service.js';
 import type { AuthServiceDeps } from './auth.types.js';
 
+/**
+ * Builds the auth router: register, login, refresh, logout, password reset,
+ * email verification, and `GET /me`. Password reset, email verification, and
+ * OAuth linking are only active when their corresponding repo/callback deps
+ * are provided; otherwise those routes respond with `NotConfiguredError`.
+ */
 export function createAuthRouter(deps: AuthServiceDeps) {
   const router = Router();
   const service = makeAuthService(deps);

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -107,6 +107,13 @@ async function issueTokens(
   return { accessToken, refreshToken, refreshTokenId, familyId: resolvedFamilyId };
 }
 
+/**
+ * Builds the auth service used by `createAuthRouter`. Can also be used
+ * directly to drive auth from a custom transport (CLI, GraphQL, etc.).
+ * Optional deps (`refreshTokenRepo`, `passwordResetTokenRepo`,
+ * `emailVerificationTokenRepo`, `oauthAccountRepo`) enable the matching
+ * flow; without them the relevant methods throw a `*_UNSUPPORTED` error.
+ */
 export function makeAuthService(deps: AuthServiceDeps) {
   const { userRepo } = deps;
 

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -11,6 +11,11 @@ import {
 import { makeUserService } from './user.service.js';
 import type { UserRepo } from '../../core/ports/user.repo.js';
 
+/**
+ * Builds the user CRUD router: admin list/create/update/delete plus
+ * `GET/PUT /me` for the authenticated user. Admin routes require an
+ * `ADMIN` bearer token; `/:id` routes allow the resource owner or an admin.
+ */
 export function createUserRouter(deps: { userRepo: UserRepo }) {
   const router = Router();
   const service = makeUserService({ userRepo: deps.userRepo });


### PR DESCRIPTION
Closes #21.

## Summary
Adds JSDoc to the exported functions/types consumers actually interact with: `createServer`, `createLibrary`, `mountDefaultRoutes`, `LibraryConfig`/`LibraryDeps`, `createAuthRouter`, `createUserRouter`, `makeAuthService`, the `UserRepo` port, `isAuth`/`hasRole`/`isSelfOrAdmin`, and the Prisma adapter factories. No behavior changes.

## Test plan
- [x] `npm run build`
- [x] `npm test` (14/14 passing)