### PR TITLE
feat: official in-memory UserRepo adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,23 @@ export interface UserRepo {
 }
 ```
 
+## In-Memory Adapter
+
+For demos, prototyping, or tests without a database:
+
+```ts
+import { createLibrary, createServer } from "my-crud-lib";
+import { makeMemoryUserRepo } from "my-crud-lib/adapters/memory";
+
+const app = createServer();
+const lib = createLibrary({ routesPrefix: "/api" }, { userRepo: makeMemoryUserRepo() });
+
+app.use(lib.router);
+app.listen(3000);
+```
+
+State lives in process memory only (lost on restart, not shared across instances). It supports the full `UserRepo` contract, including `updatePassword` and `markEmailVerified`, so password reset and email verification work when paired with in-memory token repos of your own.
+
 The Prisma adapter is available from both import paths:
 
 ```ts

--- a/examples/custom-repo/README.md
+++ b/examples/custom-repo/README.md
@@ -3,3 +3,5 @@
 This example shows the shape of an app-owned `UserRepo`.
 
 It is intentionally in-memory and only useful for understanding the adapter contract. Use a real database in production.
+
+For a ready-made in-memory adapter (demos, prototyping, tests), use `makeMemoryUserRepo` from `my-crud-lib/adapters/memory` instead of writing your own.

--- a/package.json
+++ b/package.json
@@ -63,6 +63,14 @@
     "./adapters/prisma": {
       "import": "./dist/adapters/prisma.js",
       "types": "./dist/adapters/prisma.d.ts"
+    },
+    "./adapter-memory": {
+      "import": "./dist/adapter-memory.js",
+      "types": "./dist/adapter-memory.d.ts"
+    },
+    "./adapters/memory": {
+      "import": "./dist/adapters/memory.js",
+      "types": "./dist/adapters/memory.d.ts"
     }
   },
   "files": [

--- a/src/adapter-memory.ts
+++ b/src/adapter-memory.ts
@@ -1,0 +1,1 @@
+export { makeMemoryUserRepo } from './adapters/memory.js';

--- a/src/adapters/memory.ts
+++ b/src/adapters/memory.ts
@@ -1,0 +1,129 @@
+import type { UserRepo } from '../core/ports/user.repo.js';
+import type { AdminUpdateUserInput, Role, UserListItem } from '../modules/user/user.types.js';
+
+type StoredUser = UserListItem & { passwordHash: string };
+
+function toPublic(user: StoredUser): UserListItem {
+  const { passwordHash: _passwordHash, ...safeUser } = user;
+  return safeUser;
+}
+
+function matchesFilters(user: StoredUser, role?: string, search?: string): boolean {
+  if (role && user.role !== role) return false;
+  if (search?.trim()) {
+    const needle = search.trim().toLowerCase();
+    const haystack = `${user.email} ${user.name ?? ''}`.toLowerCase();
+    if (!haystack.includes(needle)) return false;
+  }
+  return true;
+}
+
+function compare(a: StoredUser, b: StoredUser, field: 'createdAt' | 'updatedAt' | 'email' | 'name', dir: 'asc' | 'desc'): number {
+  const av = field === 'name' ? a.name ?? '' : a[field];
+  const bv = field === 'name' ? b.name ?? '' : b[field];
+  const result = String(av) < String(bv) ? -1 : String(av) > String(bv) ? 1 : 0;
+  return dir === 'asc' ? result : -result;
+}
+
+/**
+ * In-memory `UserRepo` implementation with no external dependencies.
+ * Useful for demos, prototyping, and tests. State is lost on process exit
+ * and is not shared across instances — do not use in production.
+ */
+export function makeMemoryUserRepo(): UserRepo {
+  const users = new Map<number, StoredUser>();
+  let nextId = 1;
+
+  return {
+    async count({ role, search } = {}) {
+      return [...users.values()].filter((u) => matchesFilters(u, role, search)).length;
+    },
+
+    async findMany({ page, pageSize, role, search, sortField, sortDir }) {
+      const filtered = [...users.values()]
+        .filter((u) => matchesFilters(u, role, search))
+        .sort((a, b) => compare(a, b, sortField, sortDir));
+      return filtered.slice((page - 1) * pageSize, page * pageSize).map(toPublic);
+    },
+
+    async findById(id) {
+      const user = users.get(Number(id));
+      return user ? toPublic(user) : null;
+    },
+
+    async findByEmail(email) {
+      const user = [...users.values()].find((u) => u.email === email);
+      return user ? { ...toPublic(user), passwordHash: user.passwordHash } : null;
+    },
+
+    async create(input) {
+      const now = new Date().toISOString();
+      const user: StoredUser = {
+        id: nextId++,
+        email: input.email,
+        passwordHash: input.passwordHash,
+        name: input.name ?? null,
+        role: (input.role as Role) === 'ADMIN' ? 'ADMIN' : 'USER',
+        emailVerifiedAt: null,
+        createdAt: now,
+        updatedAt: now,
+        profile: { bio: input.bio ?? null, avatarUrl: input.avatarUrl ?? null },
+      };
+      users.set(Number(user.id), user);
+      return toPublic(user);
+    },
+
+    async update(id, input: AdminUpdateUserInput) {
+      const user = users.get(Number(id));
+      if (!user) throw new Error('USER_NOT_FOUND');
+      const updated: StoredUser = {
+        ...user,
+        name: input.name ?? user.name,
+        role: input.role ?? user.role,
+        updatedAt: new Date().toISOString(),
+        profile: {
+          bio: input.bio ?? user.profile?.bio ?? null,
+          avatarUrl: input.avatarUrl ?? user.profile?.avatarUrl ?? null,
+        },
+      };
+      users.set(Number(id), updated);
+      return toPublic(updated);
+    },
+
+    async delete(id) {
+      users.delete(Number(id));
+    },
+
+    async updateMe(userId, input) {
+      const user = users.get(Number(userId));
+      if (!user) throw new Error('USER_NOT_FOUND');
+      const updated: StoredUser = {
+        ...user,
+        name: input.name ?? user.name,
+        updatedAt: new Date().toISOString(),
+        profile: {
+          bio: input.bio ?? user.profile?.bio ?? null,
+          avatarUrl: input.avatarUrl ?? user.profile?.avatarUrl ?? null,
+        },
+      };
+      users.set(Number(userId), updated);
+      return toPublic(updated);
+    },
+
+    async updatePassword(id, passwordHash) {
+      const user = users.get(Number(id));
+      if (!user) throw new Error('USER_NOT_FOUND');
+      const updated: StoredUser = { ...user, passwordHash, updatedAt: new Date().toISOString() };
+      users.set(Number(id), updated);
+      return toPublic(updated);
+    },
+
+    async markEmailVerified(id, verifiedAt = new Date()) {
+      const user = users.get(Number(id));
+      if (!user) throw new Error('USER_NOT_FOUND');
+      const updated: StoredUser = { ...user, emailVerifiedAt: verifiedAt, updatedAt: new Date().toISOString() };
+      users.set(Number(id), updated);
+      return toPublic(updated);
+    },
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,7 @@ export {
   makePrismaRefreshTokenRepo,
   makePrismaUserRepo,
 } from './adapters/prisma.js';
+export { makeMemoryUserRepo } from './adapters/memory.js';
 
 import type { UserRepo } from './core/ports/user.repo.js';
 import type { AuthServiceDeps } from './modules/auth/auth.types.js';


### PR DESCRIPTION
Closes #22.

## Summary
- `makeMemoryUserRepo()` in `src/adapters/memory.ts`: full `UserRepo` implementation with no external dependencies (supports `updatePassword`, `markEmailVerified`)
- Exported from `my-crud-lib`, `my-crud-lib/adapters/memory`, and `my-crud-lib/adapter-memory` (mirrors the Prisma adapter's dual paths)
- README: new "In-Memory Adapter" section with a runnable snippet
- `examples/custom-repo/README.md` now points to the official adapter for anyone who doesn't need to write their own

## Test plan
- [x] `npm run build`
- [x] `npm test` (14/14 passing)
- [x] `npm run smoke:exports`
- [x] Manual smoke: create/findByEmail/findMany/count round-trip against `dist/adapters/memory.js`