### PR TITLE
feat: auth lifecycle hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,33 @@ app.use(
 
 These dependencies are optional. Without them, the existing stateless refresh-token flow remains available and password reset, email verification, and OAuth methods report that they are not configured.
 
+## Lifecycle Hooks
+
+Optional callbacks on `AuthServiceDeps` for reacting to auth events, e.g. sending a welcome email or writing an audit log:
+
+```ts
+app.use(
+  "/auth",
+  createAuthRouter({
+    userRepo,
+    async onUserCreated(user) {
+      await emailProvider.sendWelcome(user.email);
+    },
+    async beforeLogin({ email }) {
+      await lockoutGuard.assertNotLocked(email); // throwing aborts the login attempt
+    },
+    async onLoginSuccess(user) {
+      await auditLog.record("login", user.id);
+    },
+    async onPasswordReset(user) {
+      await auditLog.record("password-reset", user.id);
+    },
+  })
+);
+```
+
+`onUserCreated` and `beforeLogin` run before the request completes — a thrown error aborts registration/login. `onLoginSuccess` and `onPasswordReset` run after the outcome is already decided; errors thrown from them are not surfaced to the caller.
+
 ## Error Responses
 
 Routes created by this library respond to errors with a consistent shape:

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -49,6 +49,14 @@ function createId(deps: AuthServiceDeps): string {
   return deps.idFactory?.() ?? randomUUID();
 }
 
+async function runSideEffect(effect: () => Promise<void> | void): Promise<void> {
+  try {
+    await effect();
+  } catch (err) {
+    console.error('[my-crud-lib] lifecycle hook threw and was ignored:', err);
+  }
+}
+
 function createSecret(): string {
   return randomBytes(32).toString('base64url');
 }
@@ -161,8 +169,13 @@ export function makeAuthService(deps: AuthServiceDeps) {
     }
 
     const passwordHash = await bcrypt.hash(params.password, resolvePasswordHashRounds(deps.passwordHashRounds));
-    await userRepo.updatePassword(record.userId, passwordHash);
+    const updatedUser = await userRepo.updatePassword(record.userId, passwordHash);
     await deps.passwordResetTokenRepo.markUsed(record.id, { usedAt: now });
+
+    if (deps.onPasswordReset) {
+      const user = updatedUser ?? (await userRepo.findById(record.userId));
+      if (user) await runSideEffect(() => deps.onPasswordReset!(toAuthUser(user as UserWithMaybePasswordHash)));
+    }
 
     return { ok: true };
   }
@@ -275,10 +288,14 @@ export function makeAuthService(deps: AuthServiceDeps) {
       });
 
       const authUser = toAuthUser(user);
+      if (deps.onUserCreated) await deps.onUserCreated(authUser);
+
       return { user: authUser, ...(await issueTokens(authUser, deps)) };
     },
 
     async loginUser(params: LoginInput): Promise<AuthResult> {
+      if (deps.beforeLogin) await deps.beforeLogin({ email: params.email });
+
       const user = await userRepo.findByEmail(params.email);
       if (!user?.passwordHash) throw new Error('INVALID_CREDENTIALS');
 
@@ -286,7 +303,10 @@ export function makeAuthService(deps: AuthServiceDeps) {
       if (!ok) throw new Error('INVALID_CREDENTIALS');
 
       const authUser = toAuthUser(user);
-      return { user: authUser, ...(await issueTokens(authUser, deps)) };
+      const tokens = await issueTokens(authUser, deps);
+      if (deps.onLoginSuccess) await runSideEffect(() => deps.onLoginSuccess!(authUser));
+
+      return { user: authUser, ...tokens };
     },
 
     async refreshSession(refreshToken: string): Promise<AuthTokens> {

--- a/src/modules/auth/auth.types.ts
+++ b/src/modules/auth/auth.types.ts
@@ -114,6 +114,14 @@ export type AuthServiceDeps = {
   tokenHashSecret?: string;
   idFactory?: () => string;
   now?: () => Date;
+  /** Called after a new user is created via self-registration. Errors abort registration. */
+  onUserCreated?: (user: AuthUser) => Promise<void> | void;
+  /** Called before credentials are checked during login. Throw to abort the login attempt (e.g. custom lockout logic). */
+  beforeLogin?: (input: { email: string }) => Promise<void> | void;
+  /** Called after a successful login, once tokens have been issued. Errors are not thrown to the caller. */
+  onLoginSuccess?: (user: AuthUser) => Promise<void> | void;
+  /** Called after a password reset is confirmed and the new password is saved. Errors are not thrown to the caller. */
+  onPasswordReset?: (user: AuthUser) => Promise<void> | void;
 };
 
 export type AuthUser = UserListItem;

--- a/tests/auth-service.test.mjs
+++ b/tests/auth-service.test.mjs
@@ -78,3 +78,67 @@ test('auth service registers, logs in, refreshes, and reads me without Prisma', 
   const me = await service.getMe(registered.user.id);
   assert.equal(me?.email, 'reader@example.com');
 });
+
+test('auth service lifecycle hooks fire on register and login', async () => {
+  const { makeAuthService } = await import('../dist/modules/auth/auth.service.js');
+
+  const created = [];
+  const loginAttempts = [];
+  const loginSuccesses = [];
+
+  const service = makeAuthService({
+    userRepo: createMemoryUserRepo(),
+    passwordHashRounds: 4,
+    onUserCreated: (user) => created.push(user.email),
+    beforeLogin: ({ email }) => loginAttempts.push(email),
+    onLoginSuccess: (user) => loginSuccesses.push(user.email),
+  });
+
+  await service.registerUser({ email: 'hooked@example.com', password: 'password123' });
+  assert.deepEqual(created, ['hooked@example.com']);
+
+  await service.loginUser({ email: 'hooked@example.com', password: 'password123' });
+  assert.deepEqual(loginAttempts, ['hooked@example.com']);
+  assert.deepEqual(loginSuccesses, ['hooked@example.com']);
+
+  await assert.rejects(
+    () => service.loginUser({ email: 'hooked@example.com', password: 'wrong' }),
+    /INVALID_CREDENTIALS/,
+  );
+  assert.deepEqual(loginAttempts, ['hooked@example.com', 'hooked@example.com']);
+  assert.deepEqual(loginSuccesses, ['hooked@example.com']);
+});
+
+test('beforeLogin can abort a login attempt', async () => {
+  const { makeAuthService } = await import('../dist/modules/auth/auth.service.js');
+  const userRepo = createMemoryUserRepo();
+  const service = makeAuthService({
+    userRepo,
+    passwordHashRounds: 4,
+    beforeLogin: () => {
+      throw new Error('ACCOUNT_LOCKED');
+    },
+  });
+
+  await service.registerUser({ email: 'locked@example.com', password: 'password123' });
+
+  await assert.rejects(
+    () => service.loginUser({ email: 'locked@example.com', password: 'password123' }),
+    /ACCOUNT_LOCKED/,
+  );
+});
+
+test('onLoginSuccess errors do not fail the login', async () => {
+  const { makeAuthService } = await import('../dist/modules/auth/auth.service.js');
+  const service = makeAuthService({
+    userRepo: createMemoryUserRepo(),
+    passwordHashRounds: 4,
+    onLoginSuccess: () => {
+      throw new Error('NOTIFY_FAILED');
+    },
+  });
+
+  await service.registerUser({ email: 'resilient@example.com', password: 'password123' });
+  const loggedIn = await service.loginUser({ email: 'resilient@example.com', password: 'password123' });
+  assert.equal(loggedIn.user.email, 'resilient@example.com');
+});


### PR DESCRIPTION
Closes #23.

## Summary
Adds optional callbacks on `AuthServiceDeps`:
- `onUserCreated(user)` — after self-registration
- `beforeLogin({ email })` — before credential check; throwing aborts the login
- `onLoginSuccess(user)` — after tokens are issued
- `onPasswordReset(user)` — after a password reset is confirmed

`onUserCreated`/`beforeLogin` run before the outcome is decided, so a thrown error aborts the request. `onLoginSuccess`/`onPasswordReset` run after the outcome is already decided, so their errors are caught and logged via `console.error` instead of failing the request — README documents this split explicitly.

## Test plan
- [x] `npm run build`
- [x] `npm test` (17/17 passing, 3 new tests covering hook firing, abort-on-throw, and swallow-on-throw)
- [x] `npm run smoke:exports`, `smoke:auth-hardening`, `smoke:auth-service`