### PR TITLE
feat: standard Zod validation error formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,20 @@ Routes created by this library respond to errors with a consistent shape:
 }
 ```
 
-Validation errors additionally include a `details` array with Zod issues.
+Validation errors additionally include a `details` array of `{ field, message }`:
+
+```json
+{
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Validation failed",
+    "details": [
+      { "field": "email", "message": "Invalid email" },
+      { "field": "password", "message": "String must contain at least 8 character(s)" }
+    ]
+  }
+}
+```
 
 The typed error classes and helpers are available for your own routes:
 
@@ -334,6 +347,7 @@ import {
   AppError,
   EmailAlreadyExistsError,
   errorHandler,
+  formatZodIssues,
   mapKnownError,
   sendAppError,
 } from "my-crud-lib/errors";
@@ -341,7 +355,8 @@ import {
 
 - `errorHandler` is an Express error-handling middleware (`app.use(errorHandler)`) for routes outside this library that call the same services/repos and `next(err)` their failures.
 - `sendAppError(res, err)` writes the same JSON shape directly from a catch block.
-- `mapKnownError(err)` normalizes any thrown value (a plain `Error`, a Zod error, or an `AppError`) into an `AppError` with a stable `code` and `statusCode`.
+- `mapKnownError(err)` normalizes any thrown value (a plain `Error`, a `ZodError`, or an `AppError`) into an `AppError` with a stable `code` and `statusCode`; Zod issues are formatted into `details` via `formatZodIssues`.
+- `formatZodIssues(issues)` flattens `ZodIssue[]` into `{ field, message }[]` directly, for use with your own Zod schemas outside this library's routes.
 
 ## Build Checks
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -8,6 +8,8 @@ export {
   UserNotFoundError,
   ValidationError,
   errorHandler,
+  formatZodIssues,
   mapKnownError,
   sendAppError,
+  type FieldValidationIssue,
 } from './utils/errorHandler.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,8 +62,10 @@ export {
   UserNotFoundError,
   ValidationError,
   errorHandler,
+  formatZodIssues,
   mapKnownError,
   sendAppError,
+  type FieldValidationIssue,
 } from './utils/errorHandler.js';
 export {
   makePrismaEmailVerificationTokenRepo,

--- a/src/utils/errorHandler.ts
+++ b/src/utils/errorHandler.ts
@@ -1,4 +1,18 @@
 import type { NextFunction, Request, Response } from 'express';
+import type { ZodError, ZodIssue } from 'zod';
+
+export type FieldValidationIssue = {
+  field: string;
+  message: string;
+};
+
+/** Flattens Zod issues into a stable `{ field, message }[]` shape for API responses. */
+export function formatZodIssues(issues: ZodIssue[]): FieldValidationIssue[] {
+  return issues.map((issue) => ({
+    field: issue.path.length > 0 ? issue.path.join('.') : '(root)',
+    message: issue.message,
+  }));
+}
 
 export class AppError extends Error {
   readonly code: string;
@@ -51,7 +65,7 @@ export class NotConfiguredError extends AppError {
 }
 
 export class ValidationError extends AppError {
-  constructor(details: unknown, message = 'Validation failed') {
+  constructor(details: FieldValidationIssue[], message = 'Validation failed') {
     super('VALIDATION_ERROR', message, 400, details);
   }
 }
@@ -78,7 +92,7 @@ export function mapKnownError(err: unknown): AppError {
   if (err instanceof AppError) return err;
 
   if (err && typeof err === 'object' && 'issues' in err) {
-    return new ValidationError((err as { issues: unknown }).issues);
+    return new ValidationError(formatZodIssues((err as ZodError).issues));
   }
 
   const message = err instanceof Error ? err.message : undefined;

--- a/tests/error-handler.test.mjs
+++ b/tests/error-handler.test.mjs
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { z } from 'zod';
+
+test('formatZodIssues flattens Zod issues into field/message pairs', async () => {
+  const { formatZodIssues } = await import('../dist/utils/errorHandler.js');
+  const schema = z.object({ email: z.string().email(), password: z.string().min(8) });
+
+  const result = schema.safeParse({ email: 'not-an-email', password: '123' });
+  assert.equal(result.success, false);
+
+  const details = formatZodIssues(result.error.issues);
+  assert.deepEqual(details, [
+    { field: 'email', message: 'Invalid email' },
+    { field: 'password', message: 'String must contain at least 8 character(s)' },
+  ]);
+});
+
+test('mapKnownError turns a ZodError into a VALIDATION_ERROR AppError with formatted details', async () => {
+  const { mapKnownError } = await import('../dist/utils/errorHandler.js');
+  const schema = z.object({ email: z.string().email() });
+
+  const result = schema.safeParse({ email: 'nope' });
+  const appError = mapKnownError(result.error);
+
+  assert.equal(appError.code, 'VALIDATION_ERROR');
+  assert.equal(appError.statusCode, 400);
+  assert.deepEqual(appError.details, [{ field: 'email', message: 'Invalid email' }]);
+});
+
+test('mapKnownError maps known service error messages to typed errors', async () => {
+  const { mapKnownError } = await import('../dist/utils/errorHandler.js');
+
+  const emailTaken = mapKnownError(new Error('EMAIL_TAKEN'));
+  assert.equal(emailTaken.code, 'EMAIL_ALREADY_EXISTS');
+  assert.equal(emailTaken.statusCode, 409);
+
+  const unknown = mapKnownError(new Error('SOMETHING_UNEXPECTED'));
+  assert.equal(unknown.code, 'INTERNAL_ERROR');
+  assert.equal(unknown.statusCode, 500);
+});


### PR DESCRIPTION
Closes #24.

## Summary
- New `formatZodIssues(issues: ZodIssue[])` flattens Zod issues into `{ field, message }[]`
- `mapKnownError` now formats Zod errors through it, so `ValidationError.details` (and therefore every `VALIDATION_ERROR` response from the auth/user routers) is a stable field/message array instead of raw Zod issue objects
- Exported from `my-crud-lib` and `my-crud-lib/errors`
- README updated with the exact response shape and usage

This builds on #20's error handler (`mapKnownError`/`ValidationError`/`sendAppError`), which already routed Zod errors through `ValidationError` but with raw `issues` as `details`.

## Test plan
- [x] `npm run build`
- [x] `npm test` (20/20 passing — 3 new tests for `formatZodIssues` and `mapKnownError` on Zod/service errors)
- [x] `npm run smoke:exports`, `smoke:auth-hardening`, `smoke:auth-service`
- [x] Manual check: `registerSchema.parse({ email: 'not-an-email', password: '123' })` → `details: [{ field: 'email', ... }, { field: 'password', ... }]`