### PR TITLE
Release 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,22 @@ All notable changes to `my-crud-lib` are documented here.
 
 This project follows semantic versioning. Breaking changes are called out explicitly and should be reviewed before upgrading.
 
-## 2.1.0 - Unreleased
+## 3.0.0 - Unreleased
+
+### Breaking Changes
+
+- Error responses from the auth and user routers now use `{ "error": { "code", "message", "details"? } }` instead of `{ "error": "<string>" }`. HTTP status codes are unchanged. Validation error `details` are now a formatted `{ field, message }[]` array instead of raw Zod issues.
+
+### Added
+
+- Added a CLI scaffolding command (`npx my-crud-lib init`) that generates a starter Prisma schema, `.env`, and Express server.
+- Added typed error classes (`AppError`, `EmailAlreadyExistsError`, `InvalidCredentialsError`, `UserNotFoundError`, `TokenExpiredError`, `ForbiddenError`, `NotConfiguredError`, `ValidationError`) and `mapKnownError`/`sendAppError`/`errorHandler` helpers, exported from `my-crud-lib` and a new `my-crud-lib/errors` entry point.
+- Added `formatZodIssues` to flatten Zod issues into `{ field, message }[]`, used for `ValidationError` details.
+- Added an official dependency-free in-memory `UserRepo` adapter (`makeMemoryUserRepo`), exported from `my-crud-lib`, `my-crud-lib/adapters/memory`, and `my-crud-lib/adapter-memory`.
+- Added optional auth lifecycle hooks (`onUserCreated`, `beforeLogin`, `onLoginSuccess`, `onPasswordReset`) on `AuthServiceDeps`.
+- Added JSDoc to the public API surface for IDE hover/autocomplete hints.
+
+## 2.1.0 - 2026-05-14
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -268,6 +268,37 @@ app.use(
 
 These dependencies are optional. Without them, the existing stateless refresh-token flow remains available and password reset, email verification, and OAuth methods report that they are not configured.
 
+## Error Responses
+
+Routes created by this library respond to errors with a consistent shape:
+
+```json
+{
+  "error": {
+    "code": "INVALID_CREDENTIALS",
+    "message": "Invalid credentials"
+  }
+}
+```
+
+Validation errors additionally include a `details` array with Zod issues.
+
+The typed error classes and helpers are available for your own routes:
+
+```ts
+import {
+  AppError,
+  EmailAlreadyExistsError,
+  errorHandler,
+  mapKnownError,
+  sendAppError,
+} from "my-crud-lib/errors";
+```
+
+- `errorHandler` is an Express error-handling middleware (`app.use(errorHandler)`) for routes outside this library that call the same services/repos and `next(err)` their failures.
+- `sendAppError(res, err)` writes the same JSON shape directly from a catch block.
+- `mapKnownError(err)` normalizes any thrown value (a plain `Error`, a Zod error, or an `AppError`) into an `AppError` with a stable `code` and `statusCode`.
+
 ## Build Checks
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -325,7 +325,20 @@ Routes created by this library respond to errors with a consistent shape:
 }
 ```
 
-Validation errors additionally include a `details` array with Zod issues.
+Validation errors additionally include a `details` array of `{ field, message }`:
+
+```json
+{
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Validation failed",
+    "details": [
+      { "field": "email", "message": "Invalid email" },
+      { "field": "password", "message": "String must contain at least 8 character(s)" }
+    ]
+  }
+}
+```
 
 The typed error classes and helpers are available for your own routes:
 
@@ -334,6 +347,7 @@ import {
   AppError,
   EmailAlreadyExistsError,
   errorHandler,
+  formatZodIssues,
   mapKnownError,
   sendAppError,
 } from "my-crud-lib/errors";
@@ -341,7 +355,8 @@ import {
 
 - `errorHandler` is an Express error-handling middleware (`app.use(errorHandler)`) for routes outside this library that call the same services/repos and `next(err)` their failures.
 - `sendAppError(res, err)` writes the same JSON shape directly from a catch block.
-- `mapKnownError(err)` normalizes any thrown value (a plain `Error`, a Zod error, or an `AppError`) into an `AppError` with a stable `code` and `statusCode`.
+- `mapKnownError(err)` normalizes any thrown value (a plain `Error`, a `ZodError`, or an `AppError`) into an `AppError` with a stable `code` and `statusCode`; Zod issues are formatted into `details` via `formatZodIssues`.
+- `formatZodIssues(issues)` flattens `ZodIssue[]` into `{ field, message }[]` directly, for use with your own Zod schemas outside this library's routes.
 
 ## Build Checks
 

--- a/README.md
+++ b/README.md
@@ -285,6 +285,33 @@ app.use(
 
 These dependencies are optional. Without them, the existing stateless refresh-token flow remains available and password reset, email verification, and OAuth methods report that they are not configured.
 
+## Lifecycle Hooks
+
+Optional callbacks on `AuthServiceDeps` for reacting to auth events, e.g. sending a welcome email or writing an audit log:
+
+```ts
+app.use(
+  "/auth",
+  createAuthRouter({
+    userRepo,
+    async onUserCreated(user) {
+      await emailProvider.sendWelcome(user.email);
+    },
+    async beforeLogin({ email }) {
+      await lockoutGuard.assertNotLocked(email); // throwing aborts the login attempt
+    },
+    async onLoginSuccess(user) {
+      await auditLog.record("login", user.id);
+    },
+    async onPasswordReset(user) {
+      await auditLog.record("password-reset", user.id);
+    },
+  })
+);
+```
+
+`onUserCreated` and `beforeLogin` run before the request completes — a thrown error aborts registration/login. `onLoginSuccess` and `onPasswordReset` run after the outcome is already decided; errors thrown from them are not surfaced to the caller.
+
 ## Error Responses
 
 Routes created by this library respond to errors with a consistent shape:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ BCRYPT_SALT="10"
 
 `JWT_ACCESS_EXPIRES_IN` and `JWT_REFRESH_EXPIRES_IN` have defaults. `JWT_SECRET` and `DATABASE_URL` must be set before using the default auth and Prisma paths.
 
+## CLI Scaffolding
+
+Generate a starter Prisma schema, `.env`, and Express server in the current directory:
+
+```bash
+npx my-crud-lib init
+```
+
+This creates `prisma/schema.prisma`, `src/server.ts`, and `.env` (skipping any that already exist). Edit `.env` with your `DATABASE_URL` and `JWT_SECRET`, then follow the printed next steps to install dependencies and run the server.
+
 ## Quickstart With Express And Prisma
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -223,6 +223,23 @@ export interface UserRepo {
 }
 ```
 
+## In-Memory Adapter
+
+For demos, prototyping, or tests without a database:
+
+```ts
+import { createLibrary, createServer } from "my-crud-lib";
+import { makeMemoryUserRepo } from "my-crud-lib/adapters/memory";
+
+const app = createServer();
+const lib = createLibrary({ routesPrefix: "/api" }, { userRepo: makeMemoryUserRepo() });
+
+app.use(lib.router);
+app.listen(3000);
+```
+
+State lives in process memory only (lost on restart, not shared across instances). It supports the full `UserRepo` contract, including `updatePassword` and `markEmailVerified`, so password reset and email verification work when paired with in-memory token repos of your own.
+
 The Prisma adapter is available from both import paths:
 
 ```ts

--- a/bin/init.mjs
+++ b/bin/init.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+import { existsSync, mkdirSync, copyFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const packageRoot = path.resolve(fileURLToPath(import.meta.url), '..', '..');
+const templateRoot = path.join(packageRoot, 'templates', 'init');
+const cwd = process.cwd();
+
+const files = [
+  { from: path.join(templateRoot, 'prisma', 'schema.prisma'), to: path.join(cwd, 'prisma', 'schema.prisma') },
+  { from: path.join(templateRoot, 'src', 'server.ts'), to: path.join(cwd, 'src', 'server.ts') },
+  { from: path.join(templateRoot, 'env.example'), to: path.join(cwd, '.env') },
+];
+
+function copyTemplate({ from, to }) {
+  if (existsSync(to)) {
+    console.log(`skip  ${path.relative(cwd, to)} (already exists)`);
+    return;
+  }
+  mkdirSync(path.dirname(to), { recursive: true });
+  copyFileSync(from, to);
+  console.log(`create ${path.relative(cwd, to)}`);
+}
+
+console.log('Scaffolding my-crud-lib project...\n');
+for (const file of files) copyTemplate(file);
+
+console.log(`
+Next steps:
+  npm i my-crud-lib express cors body-parser @prisma/client prisma dotenv
+  npx prisma generate
+  npx prisma migrate dev --name init
+  npx ts-node src/server.ts
+
+Edit .env with your DATABASE_URL and JWT_SECRET before starting the server.
+`);

--- a/examples/custom-repo/README.md
+++ b/examples/custom-repo/README.md
@@ -3,3 +3,5 @@
 This example shows the shape of an app-owned `UserRepo`.
 
 It is intentionally in-memory and only useful for understanding the adapter contract. Use a real database in production.
+
+For a ready-made in-memory adapter (demos, prototyping, tests), use `makeMemoryUserRepo` from `my-crud-lib/adapters/memory` instead of writing your own.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,21 @@
 {
   "name": "my-crud-lib",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "my-crud-lib",
-      "version": "2.1.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "bcryptjs": "^2.4.3",
         "dotenv": "^16.3.1",
         "jsonwebtoken": "^9.0.2",
         "zod": "^3.23.8"
+      },
+      "bin": {
+        "my-crud-lib": "bin/init.mjs"
       },
       "devDependencies": {
         "@prisma/client": "^6.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-crud-lib",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "TypeScript auth and user/profile CRUD helpers for Express with Prisma and custom repository adapters",
   "license": "MIT",
   "author": "Riccardo Sensi",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,10 @@
       "import": "./dist/middleware.js",
       "types": "./dist/middleware.d.ts"
     },
+    "./errors": {
+      "import": "./dist/errors.js",
+      "types": "./dist/errors.d.ts"
+    },
     "./adapter-prisma": {
       "import": "./dist/adapter-prisma.js",
       "types": "./dist/adapter-prisma.d.ts"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   "sideEffects": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "bin": {
+    "my-crud-lib": "bin/init.mjs"
+  },
   "keywords": [
     "auth",
     "authentication",
@@ -62,6 +65,8 @@
     "dist",
     "docs",
     "examples",
+    "bin",
+    "templates",
     "CHANGELOG.md",
     "README.md",
     "RELEASE.md",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,14 @@
     "./adapters/prisma": {
       "import": "./dist/adapters/prisma.js",
       "types": "./dist/adapters/prisma.d.ts"
+    },
+    "./adapter-memory": {
+      "import": "./dist/adapter-memory.js",
+      "types": "./dist/adapter-memory.d.ts"
+    },
+    "./adapters/memory": {
+      "import": "./dist/adapters/memory.js",
+      "types": "./dist/adapters/memory.d.ts"
     }
   },
   "files": [

--- a/src/adapter-memory.ts
+++ b/src/adapter-memory.ts
@@ -1,0 +1,1 @@
+export { makeMemoryUserRepo } from './adapters/memory.js';

--- a/src/adapters/memory.ts
+++ b/src/adapters/memory.ts
@@ -1,0 +1,129 @@
+import type { UserRepo } from '../core/ports/user.repo.js';
+import type { AdminUpdateUserInput, Role, UserListItem } from '../modules/user/user.types.js';
+
+type StoredUser = UserListItem & { passwordHash: string };
+
+function toPublic(user: StoredUser): UserListItem {
+  const { passwordHash: _passwordHash, ...safeUser } = user;
+  return safeUser;
+}
+
+function matchesFilters(user: StoredUser, role?: string, search?: string): boolean {
+  if (role && user.role !== role) return false;
+  if (search?.trim()) {
+    const needle = search.trim().toLowerCase();
+    const haystack = `${user.email} ${user.name ?? ''}`.toLowerCase();
+    if (!haystack.includes(needle)) return false;
+  }
+  return true;
+}
+
+function compare(a: StoredUser, b: StoredUser, field: 'createdAt' | 'updatedAt' | 'email' | 'name', dir: 'asc' | 'desc'): number {
+  const av = field === 'name' ? a.name ?? '' : a[field];
+  const bv = field === 'name' ? b.name ?? '' : b[field];
+  const result = String(av) < String(bv) ? -1 : String(av) > String(bv) ? 1 : 0;
+  return dir === 'asc' ? result : -result;
+}
+
+/**
+ * In-memory `UserRepo` implementation with no external dependencies.
+ * Useful for demos, prototyping, and tests. State is lost on process exit
+ * and is not shared across instances — do not use in production.
+ */
+export function makeMemoryUserRepo(): UserRepo {
+  const users = new Map<number, StoredUser>();
+  let nextId = 1;
+
+  return {
+    async count({ role, search } = {}) {
+      return [...users.values()].filter((u) => matchesFilters(u, role, search)).length;
+    },
+
+    async findMany({ page, pageSize, role, search, sortField, sortDir }) {
+      const filtered = [...users.values()]
+        .filter((u) => matchesFilters(u, role, search))
+        .sort((a, b) => compare(a, b, sortField, sortDir));
+      return filtered.slice((page - 1) * pageSize, page * pageSize).map(toPublic);
+    },
+
+    async findById(id) {
+      const user = users.get(Number(id));
+      return user ? toPublic(user) : null;
+    },
+
+    async findByEmail(email) {
+      const user = [...users.values()].find((u) => u.email === email);
+      return user ? { ...toPublic(user), passwordHash: user.passwordHash } : null;
+    },
+
+    async create(input) {
+      const now = new Date().toISOString();
+      const user: StoredUser = {
+        id: nextId++,
+        email: input.email,
+        passwordHash: input.passwordHash,
+        name: input.name ?? null,
+        role: (input.role as Role) === 'ADMIN' ? 'ADMIN' : 'USER',
+        emailVerifiedAt: null,
+        createdAt: now,
+        updatedAt: now,
+        profile: { bio: input.bio ?? null, avatarUrl: input.avatarUrl ?? null },
+      };
+      users.set(Number(user.id), user);
+      return toPublic(user);
+    },
+
+    async update(id, input: AdminUpdateUserInput) {
+      const user = users.get(Number(id));
+      if (!user) throw new Error('USER_NOT_FOUND');
+      const updated: StoredUser = {
+        ...user,
+        name: input.name ?? user.name,
+        role: input.role ?? user.role,
+        updatedAt: new Date().toISOString(),
+        profile: {
+          bio: input.bio ?? user.profile?.bio ?? null,
+          avatarUrl: input.avatarUrl ?? user.profile?.avatarUrl ?? null,
+        },
+      };
+      users.set(Number(id), updated);
+      return toPublic(updated);
+    },
+
+    async delete(id) {
+      users.delete(Number(id));
+    },
+
+    async updateMe(userId, input) {
+      const user = users.get(Number(userId));
+      if (!user) throw new Error('USER_NOT_FOUND');
+      const updated: StoredUser = {
+        ...user,
+        name: input.name ?? user.name,
+        updatedAt: new Date().toISOString(),
+        profile: {
+          bio: input.bio ?? user.profile?.bio ?? null,
+          avatarUrl: input.avatarUrl ?? user.profile?.avatarUrl ?? null,
+        },
+      };
+      users.set(Number(userId), updated);
+      return toPublic(updated);
+    },
+
+    async updatePassword(id, passwordHash) {
+      const user = users.get(Number(id));
+      if (!user) throw new Error('USER_NOT_FOUND');
+      const updated: StoredUser = { ...user, passwordHash, updatedAt: new Date().toISOString() };
+      users.set(Number(id), updated);
+      return toPublic(updated);
+    },
+
+    async markEmailVerified(id, verifiedAt = new Date()) {
+      const user = users.get(Number(id));
+      if (!user) throw new Error('USER_NOT_FOUND');
+      const updated: StoredUser = { ...user, emailVerifiedAt: verifiedAt, updatedAt: new Date().toISOString() };
+      users.set(Number(id), updated);
+      return toPublic(updated);
+    },
+  };
+}

--- a/src/adapters/prisma.ts
+++ b/src/adapters/prisma.ts
@@ -10,6 +10,7 @@ import type { AdminUpdateUserInput, UserListItem } from '../modules/user/user.ty
 
 const dateOrNow = (value?: Date) => value ?? new Date();
 
+/** `UserRepo` implementation backed by the bundled Prisma schema (`prisma/schema.prisma`). */
 export function makePrismaUserRepo(prisma: PrismaClient): UserRepo {
   return {
     async count({ role, search }) {
@@ -181,6 +182,7 @@ export function makePrismaUserRepo(prisma: PrismaClient): UserRepo {
   };
 }
 
+/** `RefreshTokenRepo` implementation; pass it to `createAuthRouter` to enable persistent refresh token rotation/revocation. */
 export function makePrismaRefreshTokenRepo(prisma: PrismaClient): RefreshTokenRepo {
   return {
     create(input) {
@@ -210,6 +212,7 @@ export function makePrismaRefreshTokenRepo(prisma: PrismaClient): RefreshTokenRe
   };
 }
 
+/** `PasswordResetTokenRepo` implementation; pass it (with `sendPasswordReset`) to `createAuthRouter` to enable the password reset flow. */
 export function makePrismaPasswordResetTokenRepo(prisma: PrismaClient): PasswordResetTokenRepo {
   return {
     create(input) {
@@ -236,6 +239,7 @@ export function makePrismaPasswordResetTokenRepo(prisma: PrismaClient): Password
   };
 }
 
+/** `EmailVerificationTokenRepo` implementation; pass it (with `sendEmailVerification`) to `createAuthRouter` to enable the email verification flow. */
 export function makePrismaEmailVerificationTokenRepo(prisma: PrismaClient): EmailVerificationTokenRepo {
   return {
     create(input) {
@@ -262,6 +266,7 @@ export function makePrismaEmailVerificationTokenRepo(prisma: PrismaClient): Emai
   };
 }
 
+/** `OAuthAccountRepo` implementation; pass it to `createAuthRouter` to enable OAuth account linking. */
 export function makePrismaOAuthAccountRepo(prisma: PrismaClient): OAuthAccountRepo {
   return {
     findByProviderAccount(provider, providerAccountId) {

--- a/src/core/ports/user.repo.ts
+++ b/src/core/ports/user.repo.ts
@@ -1,7 +1,14 @@
 import type { AdminCreateUserInput, AdminUpdateUserInput, ListUsersQuery, UserListItem } from "../../modules/user/user.types.js";
 
+/**
+ * Storage port implemented by every adapter (Prisma, in-memory, or custom).
+ * `updatePassword` and `markEmailVerified` are optional; omitting them
+ * disables password reset and email verification respectively.
+ */
 export interface UserRepo {
+  /** Counts users matching the given filters, for pagination totals. */
   count(where: { role?: string; search?: string } ): Promise<number>;
+  /** Returns one page of users, sorted per `sortField`/`sortDir`. */
   findMany(params: {
     page: number;
     pageSize: number;
@@ -11,11 +18,15 @@ export interface UserRepo {
     sortDir: 'asc'|'desc';
   }): Promise<UserListItem[]>;
   findById(id: number | string): Promise<UserListItem | null>;
+  /** Must include `passwordHash` so the auth service can verify credentials. */
   findByEmail(email: string): Promise<UserListItem & { passwordHash?: string } | null>;
   create(input: { email: string; passwordHash: string; name?: string | null; role?: string; bio?: string | null; avatarUrl?: string | null }): Promise<UserListItem>;
   update(id: number | string, input: AdminUpdateUserInput): Promise<UserListItem>;
   delete(id: number | string): Promise<void>;
+  /** Self-service update, restricted to the profile fields a user may change on their own account. */
   updateMe(userId: number | string, input: { name?: string | null; bio?: string | null; avatarUrl?: string | null }): Promise<UserListItem>;
+  /** Required for the password reset flow; omit to leave it unsupported. */
   updatePassword?(id: number | string, passwordHash: string): Promise<UserListItem | void>;
+  /** Required for the email verification flow; omit to leave it unsupported. */
   markEmailVerified?(id: number | string, verifiedAt?: Date): Promise<UserListItem | void>;
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -8,6 +8,8 @@ export {
   UserNotFoundError,
   ValidationError,
   errorHandler,
+  formatZodIssues,
   mapKnownError,
   sendAppError,
+  type FieldValidationIssue,
 } from './utils/errorHandler.js';

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,13 @@
+export {
+  AppError,
+  EmailAlreadyExistsError,
+  ForbiddenError,
+  InvalidCredentialsError,
+  NotConfiguredError,
+  TokenExpiredError,
+  UserNotFoundError,
+  ValidationError,
+  errorHandler,
+  mapKnownError,
+  sendAppError,
+} from './utils/errorHandler.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,19 @@ export {
 export { isAuth, type AuthRequest } from './middleware/isAuth.js';
 export { hasRole, isSelfOrAdmin } from './middleware/hasRole.js';
 export {
+  AppError,
+  EmailAlreadyExistsError,
+  ForbiddenError,
+  InvalidCredentialsError,
+  NotConfiguredError,
+  TokenExpiredError,
+  UserNotFoundError,
+  ValidationError,
+  errorHandler,
+  mapKnownError,
+  sendAppError,
+} from './utils/errorHandler.js';
+export {
   makePrismaEmailVerificationTokenRepo,
   makePrismaOAuthAccountRepo,
   makePrismaPasswordResetTokenRepo,

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,7 @@ export {
   makePrismaRefreshTokenRepo,
   makePrismaUserRepo,
 } from './adapters/prisma.js';
+export { makeMemoryUserRepo } from './adapters/memory.js';
 
 import type { UserRepo } from './core/ports/user.repo.js';
 import type { AuthServiceDeps } from './modules/auth/auth.types.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,8 +62,10 @@ export {
   UserNotFoundError,
   ValidationError,
   errorHandler,
+  formatZodIssues,
   mapKnownError,
   sendAppError,
+  type FieldValidationIssue,
 } from './utils/errorHandler.js';
 export {
   makePrismaEmailVerificationTokenRepo,

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,11 +78,15 @@ import type { AuthServiceDeps } from './modules/auth/auth.types.js';
 import { createAuthRouter } from './modules/auth/auth.controller.js';
 import { createUserRouter } from './modules/user/user.controller.js';
 
+/** Options for `createLibrary`/`mountDefaultRoutes`. */
 export type LibraryConfig = {
+  /** Prefix applied to all mounted routes, e.g. `/api`. */
   routesPrefix?: string;
+  /** Passed through to `createAuthRouter` alongside `deps.userRepo`. */
   auth?: Omit<AuthServiceDeps, 'userRepo'>;
 };
 
+/** Dependencies for `createLibrary`/`mountDefaultRoutes`. */
 export type LibraryDeps = {
   userRepo: UserRepo;
 };
@@ -95,6 +99,7 @@ function normalizePrefix(prefix?: string): string {
   return withLeadingSlash.endsWith('/') ? withLeadingSlash.slice(0, -1) : withLeadingSlash;
 }
 
+/** Creates an Express app with `cors` and JSON body parsing already wired in. */
 export function createServer(): Express {
   const app = express();
   app.use(cors());
@@ -102,6 +107,14 @@ export function createServer(): Express {
   return app;
 }
 
+/**
+ * Builds the combined auth + user router for this library.
+ *
+ * @param config.routesPrefix - Path prefix for all mounted routes, e.g. `/api`. Defaults to no prefix.
+ * @param config.auth - Extra `AuthServiceDeps` (excluding `userRepo`), e.g. `passwordHashRounds` or optional token repos.
+ * @param deps.userRepo - The `UserRepo` adapter backing both auth and user CRUD.
+ * @returns `{ router }` — mount it with `app.use(router)`.
+ */
 export function createLibrary(config: LibraryConfig, deps: LibraryDeps) {
   const router = Router();
   const prefix = normalizePrefix(config.routesPrefix);
@@ -112,6 +125,7 @@ export function createLibrary(config: LibraryConfig, deps: LibraryDeps) {
   return { router };
 }
 
+/** Convenience wrapper that builds the router via `createLibrary` and mounts it on `app` directly. */
 export function mountDefaultRoutes(app: Express, deps: LibraryDeps, config: LibraryConfig = {}) {
   const { router } = createLibrary(config, deps);
   app.use(router);

--- a/src/middleware/hasRole.ts
+++ b/src/middleware/hasRole.ts
@@ -1,6 +1,7 @@
 import { Response, NextFunction } from 'express';
 import { AuthRequest } from './isAuth.js';
 
+/** Requires `req.user.role` (set by `isAuth`) to be one of `allowed`; responds 403 otherwise. */
 export function hasRole(...allowed: Array<'ADMIN' | 'USER'>) {
   return (req: AuthRequest, res: Response, next: NextFunction) => {
     const role = req.user?.role;
@@ -11,6 +12,7 @@ export function hasRole(...allowed: Array<'ADMIN' | 'USER'>) {
   };
 }
 
+/** Allows the request through if `req.user` is an admin or owns the `:id` route param; responds 403 otherwise. */
 export function isSelfOrAdmin() {
   return (req: AuthRequest, res: Response, next: NextFunction) => {
     const uid = req.user?.id;

--- a/src/middleware/isAuth.ts
+++ b/src/middleware/isAuth.ts
@@ -3,6 +3,7 @@ import { verifyToken } from '../utils/jwt.js';
 
 export type AuthRequest = Request & { user?: { id: number | string; role: 'USER' | 'ADMIN' } };
 
+/** Verifies the `Authorization: Bearer <token>` header and attaches `req.user`. Responds 401 if missing/invalid. */
 export function isAuth(req: AuthRequest, res: Response, next: NextFunction) {
   const auth = req.headers.authorization;
   if (!auth?.startsWith('Bearer ')) {

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,5 +1,6 @@
 import { Router, type Request, type Response } from 'express';
 import { isAuth, type AuthRequest } from '../../middleware/isAuth.js';
+import { sendAppError } from '../../utils/errorHandler.js';
 import {
   emailVerificationConfirmSchema,
   emailVerificationRequestSchema,
@@ -20,10 +21,8 @@ export function createAuthRouter(deps: AuthServiceDeps) {
       const data = registerSchema.parse(req.body);
       const result = await service.registerUser(data);
       return res.status(201).json(result);
-    } catch (err: any) {
-      if (err?.message === 'EMAIL_TAKEN') return res.status(409).json({ error: 'Email already registered' });
-      if (err?.issues) return res.status(400).json({ error: 'ValidationError', details: err.issues });
-      return res.status(500).json({ error: 'InternalError' });
+    } catch (err) {
+      return sendAppError(res, err);
     }
   });
 
@@ -32,34 +31,32 @@ export function createAuthRouter(deps: AuthServiceDeps) {
       const data = loginSchema.parse(req.body);
       const result = await service.loginUser(data);
       return res.json(result);
-    } catch (err: any) {
-      if (err?.message === 'INVALID_CREDENTIALS') return res.status(401).json({ error: 'Invalid credentials' });
-      if (err?.issues) return res.status(400).json({ error: 'ValidationError', details: err.issues });
-      return res.status(500).json({ error: 'InternalError' });
+    } catch (err) {
+      return sendAppError(res, err);
     }
   });
 
   router.post('/refresh', async (req: Request, res: Response) => {
     try {
       const { refreshToken } = req.body as { refreshToken?: string };
-      if (!refreshToken) return res.status(400).json({ error: 'Missing refreshToken' });
+      if (!refreshToken) return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'Missing refreshToken' } });
 
       const tokens = await service.refreshSession(refreshToken);
       return res.json(tokens);
     } catch {
-      return res.status(401).json({ error: 'Invalid or expired refresh token' });
+      return sendAppError(res, new Error('INVALID_REFRESH_TOKEN'));
     }
   });
 
   router.post('/logout', async (req: Request, res: Response) => {
     try {
       const { refreshToken } = req.body as { refreshToken?: string };
-      if (!refreshToken) return res.status(400).json({ error: 'Missing refreshToken' });
+      if (!refreshToken) return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'Missing refreshToken' } });
 
       await service.revokeRefreshToken(refreshToken);
       return res.status(204).send();
     } catch {
-      return res.status(401).json({ error: 'Invalid or expired refresh token' });
+      return sendAppError(res, new Error('INVALID_REFRESH_TOKEN'));
     }
   });
 
@@ -68,10 +65,8 @@ export function createAuthRouter(deps: AuthServiceDeps) {
       const data = passwordResetRequestSchema.parse(req.body);
       await service.requestPasswordReset(data);
       return res.status(202).json({ ok: true });
-    } catch (err: any) {
-      if (err?.message === 'PASSWORD_RESET_UNSUPPORTED') return res.status(501).json({ error: 'Password reset is not configured' });
-      if (err?.issues) return res.status(400).json({ error: 'ValidationError', details: err.issues });
-      return res.status(500).json({ error: 'InternalError' });
+    } catch (err) {
+      return sendAppError(res, err);
     }
   });
 
@@ -80,11 +75,8 @@ export function createAuthRouter(deps: AuthServiceDeps) {
       const data = passwordResetConfirmSchema.parse(req.body);
       await service.confirmPasswordReset(data);
       return res.json({ ok: true });
-    } catch (err: any) {
-      if (err?.message === 'PASSWORD_RESET_UNSUPPORTED') return res.status(501).json({ error: 'Password reset is not configured' });
-      if (err?.message === 'INVALID_PASSWORD_RESET_TOKEN') return res.status(400).json({ error: 'Invalid or expired password reset token' });
-      if (err?.issues) return res.status(400).json({ error: 'ValidationError', details: err.issues });
-      return res.status(500).json({ error: 'InternalError' });
+    } catch (err) {
+      return sendAppError(res, err);
     }
   });
 
@@ -93,10 +85,8 @@ export function createAuthRouter(deps: AuthServiceDeps) {
       const data = emailVerificationRequestSchema.parse(req.body);
       await service.requestEmailVerification(data);
       return res.status(202).json({ ok: true });
-    } catch (err: any) {
-      if (err?.message === 'EMAIL_VERIFICATION_UNSUPPORTED') return res.status(501).json({ error: 'Email verification is not configured' });
-      if (err?.issues) return res.status(400).json({ error: 'ValidationError', details: err.issues });
-      return res.status(500).json({ error: 'InternalError' });
+    } catch (err) {
+      return sendAppError(res, err);
     }
   });
 
@@ -105,18 +95,15 @@ export function createAuthRouter(deps: AuthServiceDeps) {
       const data = emailVerificationConfirmSchema.parse(req.body);
       const result = await service.confirmEmailVerification(data);
       return res.json(result);
-    } catch (err: any) {
-      if (err?.message === 'EMAIL_VERIFICATION_UNSUPPORTED') return res.status(501).json({ error: 'Email verification is not configured' });
-      if (err?.message === 'INVALID_EMAIL_VERIFICATION_TOKEN') return res.status(400).json({ error: 'Invalid or expired email verification token' });
-      if (err?.issues) return res.status(400).json({ error: 'ValidationError', details: err.issues });
-      return res.status(500).json({ error: 'InternalError' });
+    } catch (err) {
+      return sendAppError(res, err);
     }
   });
 
   router.get('/me', isAuth, async (req: AuthRequest, res: Response) => {
     const userId = req.user!.id;
     const me = await service.getMe(userId);
-    if (!me) return res.status(404).json({ error: 'User not found' });
+    if (!me) return sendAppError(res, new Error('USER_NOT_FOUND'));
     return res.json(me);
   });
 

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -12,6 +12,12 @@ import {
 import { makeAuthService } from './auth.service.js';
 import type { AuthServiceDeps } from './auth.types.js';
 
+/**
+ * Builds the auth router: register, login, refresh, logout, password reset,
+ * email verification, and `GET /me`. Password reset, email verification, and
+ * OAuth linking are only active when their corresponding repo/callback deps
+ * are provided; otherwise those routes respond with `NotConfiguredError`.
+ */
 export function createAuthRouter(deps: AuthServiceDeps) {
   const router = Router();
   const service = makeAuthService(deps);

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -49,6 +49,14 @@ function createId(deps: AuthServiceDeps): string {
   return deps.idFactory?.() ?? randomUUID();
 }
 
+async function runSideEffect(effect: () => Promise<void> | void): Promise<void> {
+  try {
+    await effect();
+  } catch (err) {
+    console.error('[my-crud-lib] lifecycle hook threw and was ignored:', err);
+  }
+}
+
 function createSecret(): string {
   return randomBytes(32).toString('base64url');
 }
@@ -161,8 +169,13 @@ export function makeAuthService(deps: AuthServiceDeps) {
     }
 
     const passwordHash = await bcrypt.hash(params.password, resolvePasswordHashRounds(deps.passwordHashRounds));
-    await userRepo.updatePassword(record.userId, passwordHash);
+    const updatedUser = await userRepo.updatePassword(record.userId, passwordHash);
     await deps.passwordResetTokenRepo.markUsed(record.id, { usedAt: now });
+
+    if (deps.onPasswordReset) {
+      const user = updatedUser ?? (await userRepo.findById(record.userId));
+      if (user) await runSideEffect(() => deps.onPasswordReset!(toAuthUser(user as UserWithMaybePasswordHash)));
+    }
 
     return { ok: true };
   }
@@ -275,10 +288,14 @@ export function makeAuthService(deps: AuthServiceDeps) {
       });
 
       const authUser = toAuthUser(user);
+      if (deps.onUserCreated) await deps.onUserCreated(authUser);
+
       return { user: authUser, ...(await issueTokens(authUser, deps)) };
     },
 
     async loginUser(params: LoginInput): Promise<AuthResult> {
+      if (deps.beforeLogin) await deps.beforeLogin({ email: params.email });
+
       const user = await userRepo.findByEmail(params.email);
       if (!user?.passwordHash) throw new Error('INVALID_CREDENTIALS');
 
@@ -286,7 +303,10 @@ export function makeAuthService(deps: AuthServiceDeps) {
       if (!ok) throw new Error('INVALID_CREDENTIALS');
 
       const authUser = toAuthUser(user);
-      return { user: authUser, ...(await issueTokens(authUser, deps)) };
+      const tokens = await issueTokens(authUser, deps);
+      if (deps.onLoginSuccess) await runSideEffect(() => deps.onLoginSuccess!(authUser));
+
+      return { user: authUser, ...tokens };
     },
 
     async refreshSession(refreshToken: string): Promise<AuthTokens> {

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -107,6 +107,13 @@ async function issueTokens(
   return { accessToken, refreshToken, refreshTokenId, familyId: resolvedFamilyId };
 }
 
+/**
+ * Builds the auth service used by `createAuthRouter`. Can also be used
+ * directly to drive auth from a custom transport (CLI, GraphQL, etc.).
+ * Optional deps (`refreshTokenRepo`, `passwordResetTokenRepo`,
+ * `emailVerificationTokenRepo`, `oauthAccountRepo`) enable the matching
+ * flow; without them the relevant methods throw a `*_UNSUPPORTED` error.
+ */
 export function makeAuthService(deps: AuthServiceDeps) {
   const { userRepo } = deps;
 

--- a/src/modules/auth/auth.types.ts
+++ b/src/modules/auth/auth.types.ts
@@ -114,6 +114,14 @@ export type AuthServiceDeps = {
   tokenHashSecret?: string;
   idFactory?: () => string;
   now?: () => Date;
+  /** Called after a new user is created via self-registration. Errors abort registration. */
+  onUserCreated?: (user: AuthUser) => Promise<void> | void;
+  /** Called before credentials are checked during login. Throw to abort the login attempt (e.g. custom lockout logic). */
+  beforeLogin?: (input: { email: string }) => Promise<void> | void;
+  /** Called after a successful login, once tokens have been issued. Errors are not thrown to the caller. */
+  onLoginSuccess?: (user: AuthUser) => Promise<void> | void;
+  /** Called after a password reset is confirmed and the new password is saved. Errors are not thrown to the caller. */
+  onPasswordReset?: (user: AuthUser) => Promise<void> | void;
 };
 
 export type AuthUser = UserListItem;

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -11,6 +11,11 @@ import {
 import { makeUserService } from './user.service.js';
 import type { UserRepo } from '../../core/ports/user.repo.js';
 
+/**
+ * Builds the user CRUD router: admin list/create/update/delete plus
+ * `GET/PUT /me` for the authenticated user. Admin routes require an
+ * `ADMIN` bearer token; `/:id` routes allow the resource owner or an admin.
+ */
 export function createUserRouter(deps: { userRepo: UserRepo }) {
   const router = Router();
   const service = makeUserService({ userRepo: deps.userRepo });

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { isAuth, type AuthRequest } from '../../middleware/isAuth.js';
 import { hasRole, isSelfOrAdmin } from '../../middleware/hasRole.js';
+import { ForbiddenError, sendAppError } from '../../utils/errorHandler.js';
 import {
   listUsersQuerySchema,
   updateMeSchema,
@@ -19,15 +20,14 @@ export function createUserRouter(deps: { userRepo: UserRepo }) {
       const q = listUsersQuerySchema.parse(req.query);
       const data = await service.listUsers(q);
       res.json(data);
-    } catch (e: any) {
-      if (e?.issues) return res.status(400).json({ error: 'ValidationError', details: e.issues });
-      res.status(500).json({ error: 'InternalError' });
+    } catch (err) {
+      sendAppError(res, err);
     }
   });
 
   router.get('/me', isAuth, async (req: AuthRequest, res) => {
     const data = await service.getUserById(req.user!.id);
-    if (!data) return res.status(404).json({ error: 'User not found' });
+    if (!data) return sendAppError(res, new Error('USER_NOT_FOUND'));
     res.json(data);
   });
 
@@ -36,9 +36,8 @@ export function createUserRouter(deps: { userRepo: UserRepo }) {
       const body = updateMeSchema.parse(req.body);
       const data = await service.updateMe(req.user!.id, body);
       res.json(data);
-    } catch (e: any) {
-      if (e?.issues) return res.status(400).json({ error: 'ValidationError', details: e.issues });
-      res.status(500).json({ error: 'InternalError' });
+    } catch (err) {
+      sendAppError(res, err);
     }
   });
 
@@ -47,51 +46,48 @@ export function createUserRouter(deps: { userRepo: UserRepo }) {
       const body = adminCreateUserSchema.parse(req.body);
       const data = await service.adminCreateUser(body);
       res.status(201).json(data);
-    } catch (e: any) {
-      if (e?.message === 'EMAIL_TAKEN') return res.status(409).json({ error: 'Email already in use' });
-      if (e?.issues) return res.status(400).json({ error: 'ValidationError', details: e.issues });
-      res.status(500).json({ error: 'InternalError' });
+    } catch (err) {
+      sendAppError(res, err);
     }
   });
 
   router.get('/:id', isAuth, isSelfOrAdmin(), async (req: AuthRequest, res) => {
     const id = Number(req.params.id);
-    if (Number.isNaN(id)) return res.status(400).json({ error: 'Invalid id' });
+    if (Number.isNaN(id)) return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'Invalid id' } });
 
     const data = await service.getUserById(id);
-    if (!data) return res.status(404).json({ error: 'User not found' });
+    if (!data) return sendAppError(res, new Error('USER_NOT_FOUND'));
     res.json(data);
   });
 
   router.put('/:id', isAuth, isSelfOrAdmin(), async (req: AuthRequest, res) => {
     try {
       const id = Number(req.params.id);
-      if (Number.isNaN(id)) return res.status(400).json({ error: 'Invalid id' });
+      if (Number.isNaN(id)) return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'Invalid id' } });
 
       const body = adminUpdateUserSchema.parse(req.body);
 
       if (req.user!.role !== 'ADMIN' && body.role) {
-        return res.status(403).json({ error: 'Forbidden: cannot change role' });
+        return sendAppError(res, new ForbiddenError('Forbidden: cannot change role'));
       }
 
       const sanitizedBody = { ...body, role: body.role === null ? undefined : body.role };
       const data = await service.adminUpdateUser(id, sanitizedBody);
       res.json(data);
-    } catch (e: any) {
-      if (e?.issues) return res.status(400).json({ error: 'ValidationError', details: e.issues });
-      res.status(500).json({ error: 'InternalError' });
+    } catch (err) {
+      sendAppError(res, err);
     }
   });
 
   router.delete('/:id', isAuth, hasRole('ADMIN'), async (req, res) => {
     try {
       const id = Number(req.params.id);
-      if (Number.isNaN(id)) return res.status(400).json({ error: 'Invalid id' });
+      if (Number.isNaN(id)) return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'Invalid id' } });
 
       await service.adminDeleteUser(id);
       res.status(204).end();
-    } catch {
-      res.status(500).json({ error: 'InternalError' });
+    } catch (err) {
+      sendAppError(res, err);
     }
   });
 

--- a/src/utils/errorHandler.ts
+++ b/src/utils/errorHandler.ts
@@ -1,0 +1,106 @@
+import type { NextFunction, Request, Response } from 'express';
+
+export class AppError extends Error {
+  readonly code: string;
+  readonly statusCode: number;
+  readonly details?: unknown;
+
+  constructor(code: string, message: string, statusCode: number, details?: unknown) {
+    super(message);
+    this.name = 'AppError';
+    this.code = code;
+    this.statusCode = statusCode;
+    this.details = details;
+  }
+}
+
+export class EmailAlreadyExistsError extends AppError {
+  constructor(message = 'Email already registered') {
+    super('EMAIL_ALREADY_EXISTS', message, 409);
+  }
+}
+
+export class InvalidCredentialsError extends AppError {
+  constructor(message = 'Invalid credentials') {
+    super('INVALID_CREDENTIALS', message, 401);
+  }
+}
+
+export class UserNotFoundError extends AppError {
+  constructor(message = 'User not found') {
+    super('USER_NOT_FOUND', message, 404);
+  }
+}
+
+export class TokenExpiredError extends AppError {
+  constructor(message = 'Invalid or expired token') {
+    super('TOKEN_EXPIRED', message, 401);
+  }
+}
+
+export class ForbiddenError extends AppError {
+  constructor(message = 'Forbidden') {
+    super('FORBIDDEN', message, 403);
+  }
+}
+
+export class NotConfiguredError extends AppError {
+  constructor(message = 'This feature is not configured') {
+    super('NOT_CONFIGURED', message, 501);
+  }
+}
+
+export class ValidationError extends AppError {
+  constructor(details: unknown, message = 'Validation failed') {
+    super('VALIDATION_ERROR', message, 400, details);
+  }
+}
+
+const KNOWN_SERVICE_ERRORS: Record<string, () => AppError> = {
+  EMAIL_TAKEN: () => new EmailAlreadyExistsError(),
+  INVALID_CREDENTIALS: () => new InvalidCredentialsError(),
+  USER_NOT_FOUND: () => new UserNotFoundError(),
+  INVALID_REFRESH_TOKEN: () => new TokenExpiredError('Invalid or expired refresh token'),
+  REFRESH_TOKEN_REPLAYED: () => new TokenExpiredError('Invalid or expired refresh token'),
+  INVALID_PASSWORD_RESET_TOKEN: () => new TokenExpiredError('Invalid or expired password reset token'),
+  INVALID_EMAIL_VERIFICATION_TOKEN: () => new TokenExpiredError('Invalid or expired email verification token'),
+  PASSWORD_RESET_UNSUPPORTED: () => new NotConfiguredError('Password reset is not configured'),
+  EMAIL_VERIFICATION_UNSUPPORTED: () => new NotConfiguredError('Email verification is not configured'),
+  OAUTH_UNSUPPORTED: () => new NotConfiguredError('OAuth sign-in is not configured'),
+};
+
+/**
+ * Normalizes any thrown value (a service-layer Error, a ZodError, or an
+ * already-typed AppError) into a single AppError shape carrying a stable
+ * `code`, HTTP `statusCode`, and human-readable `message`.
+ */
+export function mapKnownError(err: unknown): AppError {
+  if (err instanceof AppError) return err;
+
+  if (err && typeof err === 'object' && 'issues' in err) {
+    return new ValidationError((err as { issues: unknown }).issues);
+  }
+
+  const message = err instanceof Error ? err.message : undefined;
+  const factory = message ? KNOWN_SERVICE_ERRORS[message] : undefined;
+  if (factory) return factory();
+
+  return new AppError('INTERNAL_ERROR', 'Internal server error', 500);
+}
+
+/** Writes a consistent `{ error: { code, message, details? } }` JSON response for an AppError. */
+export function sendAppError(res: Response, err: unknown): void {
+  const appError = mapKnownError(err);
+  res.status(appError.statusCode).json({
+    error: {
+      code: appError.code,
+      message: appError.message,
+      ...(appError.details !== undefined ? { details: appError.details } : {}),
+    },
+  });
+}
+
+/** Express error-handling middleware. Mount last with `app.use(errorHandler)`. */
+export function errorHandler(err: unknown, _req: Request, res: Response, _next: NextFunction): void {
+  sendAppError(res, err);
+}

--- a/src/utils/errorHandler.ts
+++ b/src/utils/errorHandler.ts
@@ -1,4 +1,18 @@
 import type { NextFunction, Request, Response } from 'express';
+import type { ZodError, ZodIssue } from 'zod';
+
+export type FieldValidationIssue = {
+  field: string;
+  message: string;
+};
+
+/** Flattens Zod issues into a stable `{ field, message }[]` shape for API responses. */
+export function formatZodIssues(issues: ZodIssue[]): FieldValidationIssue[] {
+  return issues.map((issue) => ({
+    field: issue.path.length > 0 ? issue.path.join('.') : '(root)',
+    message: issue.message,
+  }));
+}
 
 export class AppError extends Error {
   readonly code: string;
@@ -51,7 +65,7 @@ export class NotConfiguredError extends AppError {
 }
 
 export class ValidationError extends AppError {
-  constructor(details: unknown, message = 'Validation failed') {
+  constructor(details: FieldValidationIssue[], message = 'Validation failed') {
     super('VALIDATION_ERROR', message, 400, details);
   }
 }
@@ -78,7 +92,7 @@ export function mapKnownError(err: unknown): AppError {
   if (err instanceof AppError) return err;
 
   if (err && typeof err === 'object' && 'issues' in err) {
-    return new ValidationError((err as { issues: unknown }).issues);
+    return new ValidationError(formatZodIssues((err as ZodError).issues));
   }
 
   const message = err instanceof Error ? err.message : undefined;

--- a/templates/init/env.example
+++ b/templates/init/env.example
@@ -1,0 +1,6 @@
+DATABASE_URL="postgresql://app:app@localhost:5432/mycrud"
+JWT_SECRET="replace-with-a-long-random-secret"
+JWT_ACCESS_EXPIRES_IN="15m"
+JWT_REFRESH_EXPIRES_IN="7d"
+BCRYPT_SALT="10"
+PORT="3000"

--- a/templates/init/prisma/schema.prisma
+++ b/templates/init/prisma/schema.prisma
@@ -1,0 +1,93 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id                      Int                      @id @default(autoincrement())
+  email                   String                   @unique
+  passwordHash            String
+  name                    String?
+  role                    Role                     @default(USER)
+  emailVerifiedAt         DateTime?
+  createdAt               DateTime                 @default(now())
+  updatedAt               DateTime                 @updatedAt
+  profile                 Profile?
+  refreshTokens           RefreshToken[]
+  passwordResetTokens     PasswordResetToken[]
+  emailVerificationTokens EmailVerificationToken[]
+  oauthAccounts           OauthAccount[]
+}
+
+model Profile {
+  id        Int     @id @default(autoincrement())
+  userId    Int     @unique
+  bio       String?
+  avatarUrl String?
+  user      User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model RefreshToken {
+  id                String    @id
+  userId            Int
+  tokenHash         String
+  familyId          String
+  expiresAt         DateTime
+  revokedAt         DateTime?
+  replacedByTokenId String?
+  createdAt         DateTime  @default(now())
+  user              User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([familyId])
+}
+
+model PasswordResetToken {
+  id        String    @id
+  userId    Int
+  tokenHash String
+  expiresAt DateTime
+  usedAt    DateTime?
+  revokedAt DateTime?
+  createdAt DateTime  @default(now())
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+}
+
+model EmailVerificationToken {
+  id        String    @id
+  userId    Int
+  tokenHash String
+  expiresAt DateTime
+  usedAt    DateTime?
+  revokedAt DateTime?
+  createdAt DateTime  @default(now())
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+}
+
+model OauthAccount {
+  id                Int      @id @default(autoincrement())
+  provider          String
+  providerAccountId String
+  userId            Int
+  email             String?
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
+  user              User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([provider, providerAccountId])
+  @@index([userId])
+  @@map("OAuthAccount")
+}
+
+enum Role {
+  USER
+  ADMIN
+}

--- a/templates/init/src/server.ts
+++ b/templates/init/src/server.ts
@@ -1,0 +1,25 @@
+import 'dotenv/config';
+import { PrismaClient } from '@prisma/client';
+import { createLibrary, createServer } from 'my-crud-lib';
+import { makePrismaUserRepo } from 'my-crud-lib/adapter-prisma';
+
+const prisma = new PrismaClient();
+const app = createServer();
+
+const lib = createLibrary(
+  {
+    routesPrefix: '/api',
+    auth: {
+      passwordHashRounds: Number(process.env.BCRYPT_SALT) || 10,
+    },
+  },
+  { userRepo: makePrismaUserRepo(prisma) },
+);
+
+app.use(lib.router);
+
+const port = Number(process.env.PORT) || 3000;
+
+app.listen(port, () => {
+  console.log(`API running on http://localhost:${port}`);
+});

--- a/tests/auth-service.test.mjs
+++ b/tests/auth-service.test.mjs
@@ -78,3 +78,67 @@ test('auth service registers, logs in, refreshes, and reads me without Prisma', 
   const me = await service.getMe(registered.user.id);
   assert.equal(me?.email, 'reader@example.com');
 });
+
+test('auth service lifecycle hooks fire on register and login', async () => {
+  const { makeAuthService } = await import('../dist/modules/auth/auth.service.js');
+
+  const created = [];
+  const loginAttempts = [];
+  const loginSuccesses = [];
+
+  const service = makeAuthService({
+    userRepo: createMemoryUserRepo(),
+    passwordHashRounds: 4,
+    onUserCreated: (user) => created.push(user.email),
+    beforeLogin: ({ email }) => loginAttempts.push(email),
+    onLoginSuccess: (user) => loginSuccesses.push(user.email),
+  });
+
+  await service.registerUser({ email: 'hooked@example.com', password: 'password123' });
+  assert.deepEqual(created, ['hooked@example.com']);
+
+  await service.loginUser({ email: 'hooked@example.com', password: 'password123' });
+  assert.deepEqual(loginAttempts, ['hooked@example.com']);
+  assert.deepEqual(loginSuccesses, ['hooked@example.com']);
+
+  await assert.rejects(
+    () => service.loginUser({ email: 'hooked@example.com', password: 'wrong' }),
+    /INVALID_CREDENTIALS/,
+  );
+  assert.deepEqual(loginAttempts, ['hooked@example.com', 'hooked@example.com']);
+  assert.deepEqual(loginSuccesses, ['hooked@example.com']);
+});
+
+test('beforeLogin can abort a login attempt', async () => {
+  const { makeAuthService } = await import('../dist/modules/auth/auth.service.js');
+  const userRepo = createMemoryUserRepo();
+  const service = makeAuthService({
+    userRepo,
+    passwordHashRounds: 4,
+    beforeLogin: () => {
+      throw new Error('ACCOUNT_LOCKED');
+    },
+  });
+
+  await service.registerUser({ email: 'locked@example.com', password: 'password123' });
+
+  await assert.rejects(
+    () => service.loginUser({ email: 'locked@example.com', password: 'password123' }),
+    /ACCOUNT_LOCKED/,
+  );
+});
+
+test('onLoginSuccess errors do not fail the login', async () => {
+  const { makeAuthService } = await import('../dist/modules/auth/auth.service.js');
+  const service = makeAuthService({
+    userRepo: createMemoryUserRepo(),
+    passwordHashRounds: 4,
+    onLoginSuccess: () => {
+      throw new Error('NOTIFY_FAILED');
+    },
+  });
+
+  await service.registerUser({ email: 'resilient@example.com', password: 'password123' });
+  const loggedIn = await service.loginUser({ email: 'resilient@example.com', password: 'password123' });
+  assert.equal(loggedIn.user.email, 'resilient@example.com');
+});

--- a/tests/error-handler.test.mjs
+++ b/tests/error-handler.test.mjs
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { z } from 'zod';
+
+test('formatZodIssues flattens Zod issues into field/message pairs', async () => {
+  const { formatZodIssues } = await import('../dist/utils/errorHandler.js');
+  const schema = z.object({ email: z.string().email(), password: z.string().min(8) });
+
+  const result = schema.safeParse({ email: 'not-an-email', password: '123' });
+  assert.equal(result.success, false);
+
+  const details = formatZodIssues(result.error.issues);
+  assert.deepEqual(details, [
+    { field: 'email', message: 'Invalid email' },
+    { field: 'password', message: 'String must contain at least 8 character(s)' },
+  ]);
+});
+
+test('mapKnownError turns a ZodError into a VALIDATION_ERROR AppError with formatted details', async () => {
+  const { mapKnownError } = await import('../dist/utils/errorHandler.js');
+  const schema = z.object({ email: z.string().email() });
+
+  const result = schema.safeParse({ email: 'nope' });
+  const appError = mapKnownError(result.error);
+
+  assert.equal(appError.code, 'VALIDATION_ERROR');
+  assert.equal(appError.statusCode, 400);
+  assert.deepEqual(appError.details, [{ field: 'email', message: 'Invalid email' }]);
+});
+
+test('mapKnownError maps known service error messages to typed errors', async () => {
+  const { mapKnownError } = await import('../dist/utils/errorHandler.js');
+
+  const emailTaken = mapKnownError(new Error('EMAIL_TAKEN'));
+  assert.equal(emailTaken.code, 'EMAIL_ALREADY_EXISTS');
+  assert.equal(emailTaken.statusCode, 409);
+
+  const unknown = mapKnownError(new Error('SOMETHING_UNEXPECTED'));
+  assert.equal(unknown.code, 'INTERNAL_ERROR');
+  assert.equal(unknown.statusCode, 500);
+});


### PR DESCRIPTION
## Version: 3.0.0

Bundles issues #19-#24 (usability improvements), merged individually into `develop` via PR #25-#30.

## Summary

- **#19** — CLI scaffolding: `npx my-crud-lib init` generates a starter Prisma schema, `.env`, and Express server.
- **#20** — Typed error classes (`AppError` + subclasses) and a public `errorHandler`/`sendAppError`/`mapKnownError`, exported from `my-crud-lib` and `my-crud-lib/errors`.
- **#21** — JSDoc on the public API surface for IDE hover/autocomplete.
- **#22** — Official dependency-free in-memory `UserRepo` adapter (`makeMemoryUserRepo`).
- **#23** — Optional auth lifecycle hooks: `onUserCreated`, `beforeLogin`, `onLoginSuccess`, `onPasswordReset`.
- **#24** — `formatZodIssues` flattens Zod validation errors into `{ field, message }[]`.

## Breaking Changes (→ major bump to 3.0.0)

Error responses from the auth and user routers changed shape:

```diff
- { "error": "Invalid credentials" }
+ { "error": { "code": "INVALID_CREDENTIALS", "message": "Invalid credentials" } }
```

HTTP status codes are unchanged. Validation error `details` are now `{ field, message }[]` instead of raw Zod issue objects. See `CHANGELOG.md` for the full 3.0.0 entry.

## Test plan
- [x] `npm run build`
- [x] `npm test` (20/20 passing)
- [x] `npm run smoke:exports`, `smoke:auth-hardening`, `smoke:auth-service`
- [x] `package.json`/`package-lock.json` bumped to `3.0.0`, `CHANGELOG.md` updated

## Not done here
No publish/deploy was performed — this PR only prepares the release. Follow `RELEASE.md` (`npm ci`, `npm run ci`, `npm pack --dry-run`, then `npm publish --access public`) after merge.