### PR TITLE
feat: optional multi-tenancy (tenantId)

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,30 @@ import {
 - `mapKnownError(err)` normalizes any thrown value (a plain `Error`, a `ZodError`, or an `AppError`) into an `AppError` with a stable `code` and `statusCode`; Zod issues are formatted into `details` via `formatZodIssues`.
 - `formatZodIssues(issues)` flattens `ZodIssue[]` into `{ field, message }[]` directly, for use with your own Zod schemas outside this library's routes.
 
+## Multi-Tenancy (SaaS)
+
+An optional `tenantId` scopes users to a tenant/organization, for SaaS deployments that share one database across customers:
+
+```ts
+import { requireTenant, isSameTenant } from "my-crud-lib/middleware";
+
+// register/create accept an optional tenantId
+await service.registerUser({ email, password, tenantId: "tenant-a" });
+
+// tenantId is embedded in access/refresh tokens and available as req.user.tenantId
+app.get("/internal/reports", isAuth, requireTenant(), handler);
+```
+
+Behavior:
+- `POST /auth/register` and `POST /users` accept an optional `tenantId`.
+- Access/refresh tokens carry `tenantId` when the user has one; `isAuth` exposes it as `req.user.tenantId`.
+- Admin `GET /users` is automatically scoped to `req.user.tenantId` when the admin's token carries one — an admin token scoped to a tenant can never list another tenant's users.
+- `GET/PUT/DELETE /users/:id` respond `404` (not `403`, to avoid leaking existence) when the target user belongs to a different tenant.
+- `requireTenant()` middleware rejects requests from tokens without a `tenantId`.
+- `isSameTenant(getResourceTenantId?)` middleware compares `req.user.tenantId` against a resolved resource tenant id (defaults to `req.params.tenantId`), for your own routes.
+
+Single-tenant apps are unaffected: omit `tenantId` everywhere and behavior is identical to before.
+
 ## Build Checks
 
 ```bash

--- a/examples/express-prisma/prisma/schema.prisma
+++ b/examples/express-prisma/prisma/schema.prisma
@@ -13,6 +13,7 @@ model User {
   passwordHash            String
   name                    String?
   role                    Role                     @default(USER)
+  tenantId                String?
   emailVerifiedAt         DateTime?
   createdAt               DateTime                 @default(now())
   updatedAt               DateTime                 @updatedAt
@@ -21,6 +22,8 @@ model User {
   passwordResetTokens     PasswordResetToken[]
   emailVerificationTokens EmailVerificationToken[]
   oauthAccounts           OauthAccount[]
+
+  @@index([tenantId])
 }
 
 model Profile {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,6 +13,7 @@ model User {
   passwordHash            String
   name                    String?
   role                    Role                     @default(USER)
+  tenantId                String?
   emailVerifiedAt         DateTime?
   createdAt               DateTime                 @default(now())
   updatedAt               DateTime                 @updatedAt
@@ -21,6 +22,8 @@ model User {
   passwordResetTokens     PasswordResetToken[]
   emailVerificationTokens EmailVerificationToken[]
   oauthAccounts           OauthAccount[]
+
+  @@index([tenantId])
 }
 
 model Profile {

--- a/src/adapters/memory.ts
+++ b/src/adapters/memory.ts
@@ -8,8 +8,9 @@ function toPublic(user: StoredUser): UserListItem {
   return safeUser;
 }
 
-function matchesFilters(user: StoredUser, role?: string, search?: string): boolean {
+function matchesFilters(user: StoredUser, role?: string, search?: string, tenantId?: string | number): boolean {
   if (role && user.role !== role) return false;
+  if (tenantId !== undefined && String(user.tenantId ?? '') !== String(tenantId)) return false;
   if (search?.trim()) {
     const needle = search.trim().toLowerCase();
     const haystack = `${user.email} ${user.name ?? ''}`.toLowerCase();
@@ -35,13 +36,13 @@ export function makeMemoryUserRepo(): UserRepo {
   let nextId = 1;
 
   return {
-    async count({ role, search } = {}) {
-      return [...users.values()].filter((u) => matchesFilters(u, role, search)).length;
+    async count({ role, search, tenantId } = {}) {
+      return [...users.values()].filter((u) => matchesFilters(u, role, search, tenantId)).length;
     },
 
-    async findMany({ page, pageSize, role, search, sortField, sortDir }) {
+    async findMany({ page, pageSize, role, search, tenantId, sortField, sortDir }) {
       const filtered = [...users.values()]
-        .filter((u) => matchesFilters(u, role, search))
+        .filter((u) => matchesFilters(u, role, search, tenantId))
         .sort((a, b) => compare(a, b, sortField, sortDir));
       return filtered.slice((page - 1) * pageSize, page * pageSize).map(toPublic);
     },
@@ -64,6 +65,7 @@ export function makeMemoryUserRepo(): UserRepo {
         passwordHash: input.passwordHash,
         name: input.name ?? null,
         role: (input.role as Role) === 'ADMIN' ? 'ADMIN' : 'USER',
+        tenantId: input.tenantId ?? null,
         emailVerifiedAt: null,
         createdAt: now,
         updatedAt: now,

--- a/src/adapters/prisma.ts
+++ b/src/adapters/prisma.ts
@@ -13,9 +13,10 @@ const dateOrNow = (value?: Date) => value ?? new Date();
 /** `UserRepo` implementation backed by the bundled Prisma schema (`prisma/schema.prisma`). */
 export function makePrismaUserRepo(prisma: PrismaClient): UserRepo {
   return {
-    async count({ role, search }) {
+    async count({ role, search, tenantId }) {
       const where: Prisma.UserWhereInput = {};
       if (role) where.role = role as any;
+      if (tenantId !== undefined) where.tenantId = String(tenantId) as any;
       if (search?.trim()) {
         const s = search.trim();
         where.OR = [
@@ -26,9 +27,10 @@ export function makePrismaUserRepo(prisma: PrismaClient): UserRepo {
       return prisma.user.count({ where });
     },
 
-    async findMany({ page, pageSize, role, search, sortField, sortDir }) {
+    async findMany({ page, pageSize, role, search, tenantId, sortField, sortDir }) {
       const where: Prisma.UserWhereInput = {};
       if (role) where.role = role as any;
+      if (tenantId !== undefined) where.tenantId = String(tenantId) as any;
       if (search?.trim()) {
         const s = search.trim();
         where.OR = [
@@ -47,6 +49,7 @@ export function makePrismaUserRepo(prisma: PrismaClient): UserRepo {
           email: true,
           name: true,
           role: true,
+          tenantId: true,
           createdAt: true,
           updatedAt: true,
           profile: { select: { bio: true, avatarUrl: true } },
@@ -63,6 +66,7 @@ export function makePrismaUserRepo(prisma: PrismaClient): UserRepo {
           email: true,
           name: true,
           role: true,
+          tenantId: true,
           createdAt: true,
           updatedAt: true,
           profile: { select: { bio: true, avatarUrl: true } },
@@ -78,6 +82,7 @@ export function makePrismaUserRepo(prisma: PrismaClient): UserRepo {
           email: true,
           name: true,
           role: true,
+          tenantId: true,
           passwordHash: true,
           createdAt: true,
           updatedAt: true,
@@ -93,10 +98,11 @@ export function makePrismaUserRepo(prisma: PrismaClient): UserRepo {
           passwordHash: input.passwordHash,
           name: input.name ?? null,
           role: (input.role as any) ?? 'USER',
+          tenantId: input.tenantId != null ? String(input.tenantId) : null,
           profile: { create: { bio: input.bio ?? null, avatarUrl: input.avatarUrl ?? null } },
         },
         select: {
-          id: true, email: true, name: true, role: true,
+          id: true, email: true, name: true, role: true, tenantId: true,
           createdAt: true, updatedAt: true,
           profile: { select: { bio: true, avatarUrl: true } },
         },

--- a/src/core/ports/user.repo.ts
+++ b/src/core/ports/user.repo.ts
@@ -7,20 +7,21 @@ import type { AdminCreateUserInput, AdminUpdateUserInput, ListUsersQuery, UserLi
  */
 export interface UserRepo {
   /** Counts users matching the given filters, for pagination totals. */
-  count(where: { role?: string; search?: string } ): Promise<number>;
+  count(where: { role?: string; search?: string; tenantId?: string | number } ): Promise<number>;
   /** Returns one page of users, sorted per `sortField`/`sortDir`. */
   findMany(params: {
     page: number;
     pageSize: number;
     role?: string;
     search?: string;
+    tenantId?: string | number;
     sortField: 'createdAt'|'updatedAt'|'email'|'name';
     sortDir: 'asc'|'desc';
   }): Promise<UserListItem[]>;
   findById(id: number | string): Promise<UserListItem | null>;
   /** Must include `passwordHash` so the auth service can verify credentials. */
   findByEmail(email: string): Promise<UserListItem & { passwordHash?: string } | null>;
-  create(input: { email: string; passwordHash: string; name?: string | null; role?: string; bio?: string | null; avatarUrl?: string | null }): Promise<UserListItem>;
+  create(input: { email: string; passwordHash: string; name?: string | null; role?: string; bio?: string | null; avatarUrl?: string | null; tenantId?: string | number | null }): Promise<UserListItem>;
   update(id: number | string, input: AdminUpdateUserInput): Promise<UserListItem>;
   delete(id: number | string): Promise<void>;
   /** Self-service update, restricted to the profile fields a user may change on their own account. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ export {
 } from './modules/user/user.schemas.js';
 export { isAuth, type AuthRequest } from './middleware/isAuth.js';
 export { hasRole, isSelfOrAdmin } from './middleware/hasRole.js';
+export { requireTenant, isSameTenant } from './middleware/tenant.js';
 export {
   AppError,
   EmailAlreadyExistsError,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,2 +1,3 @@
 export { hasRole, isSelfOrAdmin } from './middleware/hasRole.js';
 export { isAuth, type AuthRequest } from './middleware/isAuth.js';
+export { requireTenant, isSameTenant } from './middleware/tenant.js';

--- a/src/middleware/isAuth.ts
+++ b/src/middleware/isAuth.ts
@@ -1,7 +1,9 @@
 import type { Request, Response, NextFunction } from 'express';
 import { verifyToken } from '../utils/jwt.js';
 
-export type AuthRequest = Request & { user?: { id: number | string; role: 'USER' | 'ADMIN' } };
+export type AuthRequest = Request & {
+  user?: { id: number | string; role: 'USER' | 'ADMIN'; tenantId?: string | number };
+};
 
 /** Verifies the `Authorization: Bearer <token>` header and attaches `req.user`. Responds 401 if missing/invalid. */
 export function isAuth(req: AuthRequest, res: Response, next: NextFunction) {
@@ -11,8 +13,8 @@ export function isAuth(req: AuthRequest, res: Response, next: NextFunction) {
   }
   const token = auth.substring('Bearer '.length);
   try {
-    const payload = verifyToken<{ sub: number | string; role: 'USER' | 'ADMIN' }>(token);
-    req.user = { id: payload.sub, role: payload.role };
+    const payload = verifyToken<{ sub: number | string; role: 'USER' | 'ADMIN'; tenantId?: string | number }>(token);
+    req.user = { id: payload.sub, role: payload.role, ...(payload.tenantId !== undefined ? { tenantId: payload.tenantId } : {}) };
     return next();
   } catch {
     return res.status(401).json({ error: 'Invalid or expired token' });

--- a/src/middleware/tenant.ts
+++ b/src/middleware/tenant.ts
@@ -1,0 +1,30 @@
+import type { Response, NextFunction } from 'express';
+import type { AuthRequest } from './isAuth.js';
+
+/** Requires `req.user.tenantId` to be set (rejects tokens issued for a single-tenant/no-tenant context). Responds 403 otherwise. */
+export function requireTenant() {
+  return (req: AuthRequest, res: Response, next: NextFunction) => {
+    if (req.user?.tenantId === undefined) {
+      return res.status(403).json({ error: { code: 'FORBIDDEN', message: 'Forbidden: no tenant on this token' } });
+    }
+    next();
+  };
+}
+
+/**
+ * Compares `req.user.tenantId` against a tenant id resolved from the request
+ * (by default `req.params.tenantId`). Responds 403 on mismatch, or when
+ * either side is missing. Pass a custom `getResourceTenantId` to resolve the
+ * tenant id from elsewhere (e.g. a loaded resource) instead of a route param.
+ */
+export function isSameTenant(getResourceTenantId?: (req: AuthRequest) => string | number | undefined) {
+  const resolve = getResourceTenantId ?? ((req: AuthRequest) => req.params.tenantId);
+  return (req: AuthRequest, res: Response, next: NextFunction) => {
+    const userTenantId = req.user?.tenantId;
+    const resourceTenantId = resolve(req);
+    if (userTenantId === undefined || resourceTenantId === undefined || String(userTenantId) !== String(resourceTenantId)) {
+      return res.status(403).json({ error: { code: 'FORBIDDEN', message: 'Forbidden: tenant mismatch' } });
+    }
+    next();
+  };
+}

--- a/src/modules/auth/auth.schemas.ts
+++ b/src/modules/auth/auth.schemas.ts
@@ -4,6 +4,7 @@ export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
   name: z.string().min(1).max(100).nullish(),
+  tenantId: z.union([z.string(), z.number()]).nullish(),
 });
 
 export const loginSchema = z.object({

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -84,11 +84,11 @@ function safeEqual(a: string, b: string): boolean {
 }
 
 async function issueTokens(
-  user: Pick<AuthUser, 'id' | 'role'>,
+  user: Pick<AuthUser, 'id' | 'role' | 'tenantId'>,
   deps: AuthServiceDeps,
   familyId?: string,
 ): Promise<AuthTokens & { refreshTokenId?: string; familyId?: string }> {
-  const payload = { sub: user.id, role: user.role };
+  const payload = { sub: user.id, role: user.role, ...(user.tenantId != null ? { tenantId: user.tenantId } : {}) };
   const accessToken = signAccessToken(payload);
 
   if (!deps.refreshTokenRepo) {
@@ -285,6 +285,7 @@ export function makeAuthService(deps: AuthServiceDeps) {
         passwordHash,
         name: params.name ?? null,
         role,
+        tenantId: params.tenantId ?? null,
       });
 
       const authUser = toAuthUser(user);

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -20,10 +20,12 @@ export function createUserRouter(deps: { userRepo: UserRepo }) {
   const router = Router();
   const service = makeUserService({ userRepo: deps.userRepo });
 
-  router.get('/', isAuth, hasRole('ADMIN'), async (req, res) => {
+  router.get('/', isAuth, hasRole('ADMIN'), async (req: AuthRequest, res) => {
     try {
       const q = listUsersQuerySchema.parse(req.query);
-      const data = await service.listUsers(q);
+      // An admin scoped to a tenant can only ever list users within that tenant.
+      const scopedQuery = req.user!.tenantId !== undefined ? { ...q, tenantId: req.user!.tenantId } : q;
+      const data = await service.listUsers(scopedQuery);
       res.json(data);
     } catch (err) {
       sendAppError(res, err);
@@ -60,7 +62,7 @@ export function createUserRouter(deps: { userRepo: UserRepo }) {
     const id = Number(req.params.id);
     if (Number.isNaN(id)) return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'Invalid id' } });
 
-    const data = await service.getUserById(id);
+    const data = await service.getUserById(id, req.user!.tenantId);
     if (!data) return sendAppError(res, new Error('USER_NOT_FOUND'));
     res.json(data);
   });
@@ -69,6 +71,9 @@ export function createUserRouter(deps: { userRepo: UserRepo }) {
     try {
       const id = Number(req.params.id);
       if (Number.isNaN(id)) return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'Invalid id' } });
+
+      const existing = await service.getUserById(id, req.user!.tenantId);
+      if (!existing) return sendAppError(res, new Error('USER_NOT_FOUND'));
 
       const body = adminUpdateUserSchema.parse(req.body);
 
@@ -84,10 +89,13 @@ export function createUserRouter(deps: { userRepo: UserRepo }) {
     }
   });
 
-  router.delete('/:id', isAuth, hasRole('ADMIN'), async (req, res) => {
+  router.delete('/:id', isAuth, hasRole('ADMIN'), async (req: AuthRequest, res) => {
     try {
       const id = Number(req.params.id);
       if (Number.isNaN(id)) return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'Invalid id' } });
+
+      const existing = await service.getUserById(id, req.user!.tenantId);
+      if (!existing) return sendAppError(res, new Error('USER_NOT_FOUND'));
 
       await service.adminDeleteUser(id);
       res.status(204).end();

--- a/src/modules/user/user.schemas.ts
+++ b/src/modules/user/user.schemas.ts
@@ -20,6 +20,7 @@ export const listUsersQuerySchema = z.object({
     .transform((v) => (v === '' ? undefined : v))
     .optional(),
   role: z.enum(['USER', 'ADMIN']).optional(),
+  tenantId: z.union([z.string(), z.coerce.number()]).optional(),
   sort: SortEnum.default('createdAt:desc'),
 });
 
@@ -36,6 +37,7 @@ export const adminCreateUserSchema = z.object({
   role: z.enum(['USER', 'ADMIN']).default('USER'),
   bio: z.string().max(500).nullish(),
   avatarUrl: z.string().url().nullish(),
+  tenantId: z.union([z.string(), z.number()]).nullish(),
 });
 
 export const adminUpdateUserSchema = z.object({

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -25,17 +25,20 @@ export function makeUserService(deps: { userRepo: UserRepo }) {
 
   return {
     async listUsers(q: ListUsersQuery): Promise<Paginated<UserListItem>> {
-      const { page, pageSize, role, search } = q;
+      const { page, pageSize, role, search, tenantId } = q;
       const { sortField, sortDir } = parseSort(q.sort);
       const [total, items] = await Promise.all([
-        userRepo.count({ role, search }),
-        userRepo.findMany({ page, pageSize, role, search, sortField, sortDir }),
+        userRepo.count({ role, search, tenantId }),
+        userRepo.findMany({ page, pageSize, role, search, tenantId, sortField, sortDir }),
       ]);
       return { page, pageSize, total, totalPages: Math.ceil(total / pageSize), items };
     },
 
-    getUserById(id: number | string) {
-      return userRepo.findById(id);
+    async getUserById(id: number | string, tenantId?: string | number) {
+      const user = await userRepo.findById(id);
+      if (!user) return null;
+      if (tenantId !== undefined && String(user.tenantId ?? '') !== String(tenantId)) return null;
+      return user;
     },
 
     updateMe(userId: number | string, data: UpdateMeInput) {
@@ -54,6 +57,7 @@ export function makeUserService(deps: { userRepo: UserRepo }) {
         role: input.role ?? 'USER',
         bio: input.bio ?? null,
         avatarUrl: input.avatarUrl ?? null,
+        tenantId: input.tenantId ?? null,
       });
     },
 

--- a/src/modules/user/user.types.ts
+++ b/src/modules/user/user.types.ts
@@ -5,6 +5,8 @@ export type UserListItem = {
   email: string;
   name: string | null;
   role: Role;
+  /** Optional tenant/organization scope for multi-tenant SaaS deployments. Absent in single-tenant apps. */
+  tenantId?: string | number | null;
   emailVerifiedAt?: Date | string | null;
   createdAt: Date | string;
   updatedAt: Date | string;
@@ -16,6 +18,7 @@ export type ListUsersQuery = {
   pageSize: number;
   role?: Role;
   search?: string;
+  tenantId?: string | number;
   sort?: `${'createdAt'|'updatedAt'|'email'|'name'}:${'asc'|'desc'}`;
 };
 
@@ -40,6 +43,7 @@ export type AdminCreateUserInput = {
   role?: Role;
   bio?: string | null;
   avatarUrl?: string | null;
+  tenantId?: string | number | null;
 };
 
 export type AdminUpdateUserInput = {

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -7,6 +7,7 @@ export type JwtPayload = {
   typ?: "refresh";
   jti?: string;
   fam?: string;
+  tenantId?: number | string;
 };
 
 export function signAccessToken(payload: JwtPayload): string {

--- a/templates/init/prisma/schema.prisma
+++ b/templates/init/prisma/schema.prisma
@@ -13,6 +13,7 @@ model User {
   passwordHash            String
   name                    String?
   role                    Role                     @default(USER)
+  tenantId                String?
   emailVerifiedAt         DateTime?
   createdAt               DateTime                 @default(now())
   updatedAt               DateTime                 @updatedAt
@@ -21,6 +22,8 @@ model User {
   passwordResetTokens     PasswordResetToken[]
   emailVerificationTokens EmailVerificationToken[]
   oauthAccounts           OauthAccount[]
+
+  @@index([tenantId])
 }
 
 model Profile {

--- a/tests/multi-tenancy.test.mjs
+++ b/tests/multi-tenancy.test.mjs
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-secret-for-multi-tenancy-test';
+
+test('tenantId flows from registration through tokens and scoped listing', async () => {
+  const { makeAuthService } = await import('../dist/modules/auth/auth.service.js');
+  const { makeMemoryUserRepo } = await import('../dist/adapters/memory.js');
+  const { verifyToken } = await import('../dist/utils/jwt.js');
+
+  const userRepo = makeMemoryUserRepo();
+  const service = makeAuthService({ userRepo, passwordHashRounds: 4 });
+
+  const tenantA = await service.registerUser({ email: 'a@tenant-a.com', password: 'password123', tenantId: 'tenant-a' });
+  await service.registerUser({ email: 'b@tenant-b.com', password: 'password123', tenantId: 'tenant-b' });
+
+  assert.equal(tenantA.user.tenantId, 'tenant-a');
+
+  const payload = verifyToken(tenantA.accessToken);
+  assert.equal(payload.tenantId, 'tenant-a');
+
+  const onlyTenantA = await userRepo.findMany({
+    page: 1,
+    pageSize: 10,
+    tenantId: 'tenant-a',
+    sortField: 'createdAt',
+    sortDir: 'asc',
+  });
+  assert.equal(onlyTenantA.length, 1);
+  assert.equal(onlyTenantA[0].email, 'a@tenant-a.com');
+
+  const countTenantB = await userRepo.count({ tenantId: 'tenant-b' });
+  assert.equal(countTenantB, 1);
+});
+
+test('isSameTenant middleware rejects cross-tenant access', async () => {
+  const { isSameTenant, requireTenant } = await import('../dist/middleware/tenant.js');
+
+  const makeRes = () => {
+    const res = {};
+    res.statusCode = 200;
+    res.status = (code) => { res.statusCode = code; return res; };
+    res.json = (body) => { res.body = body; return res; };
+    return res;
+  };
+
+  const mismatch = { user: { id: 1, role: 'ADMIN', tenantId: 'tenant-a' }, params: { tenantId: 'tenant-b' } };
+  const res1 = makeRes();
+  let nextCalled = false;
+  isSameTenant()(mismatch, res1, () => { nextCalled = true; });
+  assert.equal(nextCalled, false);
+  assert.equal(res1.statusCode, 403);
+
+  const match = { user: { id: 1, role: 'ADMIN', tenantId: 'tenant-a' }, params: { tenantId: 'tenant-a' } };
+  const res2 = makeRes();
+  let nextCalled2 = false;
+  isSameTenant()(match, res2, () => { nextCalled2 = true; });
+  assert.equal(nextCalled2, true);
+
+  const noTenant = { user: { id: 1, role: 'ADMIN' }, params: {} };
+  const res3 = makeRes();
+  let nextCalled3 = false;
+  requireTenant()(noTenant, res3, () => { nextCalled3 = true; });
+  assert.equal(nextCalled3, false);
+  assert.equal(res3.statusCode, 403);
+});


### PR DESCRIPTION
Closes #32.

## Summary
- `tenantId` (string | number, optional) added to `UserListItem`, `UserRepo.create`/`count`/`findMany`, JWT payload, `req.user` (via `isAuth`).
- `POST /auth/register` and `POST /users` accept an optional `tenantId`.
- `GET /users` (admin) auto-scopes to `req.user.tenantId` when the admin's own token carries one — cannot be overridden by query params to escape the tenant.
- `GET/PUT/DELETE /users/:id` return `404 USER_NOT_FOUND` (not `403`) when the target belongs to a different tenant, to avoid leaking existence via status code.
- New `requireTenant()` and `isSameTenant(getResourceTenantId?)` middleware, exported from `my-crud-lib` and `my-crud-lib/middleware`, for tenant checks in custom routes.
- Prisma adapter + all three bundled Prisma schemas (`prisma/schema.prisma`, `templates/init/prisma/schema.prisma`, `examples/express-prisma/prisma/schema.prisma`) gain a nullable, indexed `tenantId` column.
- Memory adapter filters/stores `tenantId` the same way.

## Backward compatibility
Every new field is optional and additive. Apps that never set `tenantId` see identical behavior to before — `req.user.tenantId` is simply absent from the object rather than `undefined`-valued (verified in `tests/middleware.test.mjs` via `deepStrictEqual`).

## Test plan
- [x] `npm run build`
- [x] `npm test` (22/22 passing — 2 new tests for tenant-scoped registration/listing and the new middleware)
- [x] `npm run ci` (full checklist incl. `npm pack --dry-run`)