### PR TITLE
feat: API key auth for machine-to-machine requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,26 @@ Behavior:
 
 Single-tenant apps are unaffected: omit `tenantId` everywhere and behavior is identical to before.
 
+## API Keys (Machine-to-Machine Auth)
+
+For requests between internal services (workers, schedulers, other microservices) that don't have a user behind them:
+
+```ts
+import { issueApiKey, isApiKey } from "my-crud-lib";
+import { makeMemoryApiKeyRepo } from "my-crud-lib/adapters/memory"; // or makePrismaApiKeyRepo
+
+const apiKeyRepo = makeMemoryApiKeyRepo();
+
+// generate once, e.g. from an admin script; store the returned key securely — it is never retrievable again
+const { key } = await issueApiKey(apiKeyRepo, { name: "billing-service", scopes: ["users:read"] });
+
+app.get("/internal/users/:id", isApiKey(apiKeyRepo, { requiredScopes: ["users:read"] }), handler);
+```
+
+The caller sends the key back via `X-API-Key: <key>` or `Authorization: ApiKey <key>`. Only a salted hash of the key is ever persisted (via `ApiKeyRepo`); the plaintext is returned once from `issueApiKey` and cannot be recovered afterward. `isApiKey` attaches `req.apiKey = { id, name, scopes, tenantId? }` on success.
+
+To require either a user token or a service API key on the same route, chain your own small middleware that tries `isAuth` and falls back to `isApiKey`.
+
 ## Build Checks
 
 ```bash

--- a/examples/express-prisma/prisma/schema.prisma
+++ b/examples/express-prisma/prisma/schema.prisma
@@ -94,3 +94,15 @@ enum Role {
   USER
   ADMIN
 }
+
+model ApiKey {
+  id        String    @id
+  name      String?
+  keyHash   String
+  scopes    String[]  @default([])
+  tenantId  String?
+  revokedAt DateTime?
+  createdAt DateTime  @default(now())
+
+  @@index([tenantId])
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -94,3 +94,15 @@ enum Role {
   USER
   ADMIN
 }
+
+model ApiKey {
+  id        String    @id
+  name      String?
+  keyHash   String
+  scopes    String[]  @default([])
+  tenantId  String?
+  revokedAt DateTime?
+  createdAt DateTime  @default(now())
+
+  @@index([tenantId])
+}

--- a/src/adapter-memory.ts
+++ b/src/adapter-memory.ts
@@ -1,1 +1,1 @@
-export { makeMemoryUserRepo } from './adapters/memory.js';
+export { makeMemoryApiKeyRepo, makeMemoryUserRepo } from './adapters/memory.js';

--- a/src/adapter-prisma.ts
+++ b/src/adapter-prisma.ts
@@ -1,4 +1,5 @@
 export {
+  makePrismaApiKeyRepo,
   makePrismaEmailVerificationTokenRepo,
   makePrismaOAuthAccountRepo,
   makePrismaPasswordResetTokenRepo,

--- a/src/adapters/memory.ts
+++ b/src/adapters/memory.ts
@@ -1,4 +1,5 @@
 import type { UserRepo } from '../core/ports/user.repo.js';
+import type { ApiKeyRecord, ApiKeyRepo } from '../core/ports/apiKey.repo.js';
 import type { AdminUpdateUserInput, Role, UserListItem } from '../modules/user/user.types.js';
 
 type StoredUser = UserListItem & { passwordHash: string };
@@ -126,6 +127,37 @@ export function makeMemoryUserRepo(): UserRepo {
       const updated: StoredUser = { ...user, emailVerifiedAt: verifiedAt, updatedAt: new Date().toISOString() };
       users.set(Number(id), updated);
       return toPublic(updated);
+    },
+  };
+}
+
+/** In-memory `ApiKeyRepo` implementation. Useful for demos, prototyping, and tests. */
+export function makeMemoryApiKeyRepo(): ApiKeyRepo {
+  const keys = new Map<string, ApiKeyRecord>();
+
+  return {
+    async findById(id) {
+      return keys.get(id) ?? null;
+    },
+
+    async create(input) {
+      const record: ApiKeyRecord = {
+        id: input.id,
+        name: input.name ?? null,
+        keyHash: input.keyHash,
+        scopes: input.scopes ?? [],
+        tenantId: input.tenantId ?? null,
+        revokedAt: null,
+        createdAt: new Date().toISOString(),
+      };
+      keys.set(record.id, record);
+      return record;
+    },
+
+    async revoke(id, input = {}) {
+      const record = keys.get(id);
+      if (!record) return;
+      keys.set(id, { ...record, revokedAt: input.revokedAt ?? new Date() });
     },
   };
 }

--- a/src/adapters/prisma.ts
+++ b/src/adapters/prisma.ts
@@ -1,5 +1,6 @@
 import type { Prisma, PrismaClient } from '@prisma/client';
 import type { UserRepo } from '../core/ports/user.repo.js';
+import type { ApiKeyRepo } from '../core/ports/apiKey.repo.js';
 import type {
   EmailVerificationTokenRepo,
   OAuthAccountRepo,
@@ -295,6 +296,34 @@ export function makePrismaOAuthAccountRepo(prisma: PrismaClient): OAuthAccountRe
           userId: input.userId as any,
           email: input.email ?? null,
         },
+      });
+    },
+  };
+}
+
+/** `ApiKeyRepo` implementation; pass it to `isApiKey` to authenticate machine-to-machine requests. */
+export function makePrismaApiKeyRepo(prisma: PrismaClient): ApiKeyRepo {
+  return {
+    findById(id) {
+      return (prisma as any).apiKey.findUnique({ where: { id } });
+    },
+
+    create(input) {
+      return (prisma as any).apiKey.create({
+        data: {
+          id: input.id,
+          name: input.name ?? null,
+          keyHash: input.keyHash,
+          scopes: input.scopes ?? [],
+          tenantId: input.tenantId != null ? String(input.tenantId) : null,
+        },
+      });
+    },
+
+    async revoke(id, input = {}) {
+      await (prisma as any).apiKey.update({
+        where: { id },
+        data: { revokedAt: dateOrNow(input.revokedAt) },
       });
     },
   };

--- a/src/core/ports/apiKey.repo.ts
+++ b/src/core/ports/apiKey.repo.ts
@@ -1,0 +1,25 @@
+export type ApiKeyRecord = {
+  id: string;
+  name?: string | null;
+  keyHash: string;
+  scopes?: string[];
+  tenantId?: string | number | null;
+  revokedAt?: Date | string | null;
+  createdAt?: Date | string;
+};
+
+/**
+ * Storage port for machine-to-machine API keys, used by `isApiKey` to
+ * authenticate service-to-service requests without a user behind them.
+ */
+export interface ApiKeyRepo {
+  findById(id: string): Promise<ApiKeyRecord | null>;
+  create(input: {
+    id: string;
+    name?: string | null;
+    keyHash: string;
+    scopes?: string[];
+    tenantId?: string | number | null;
+  }): Promise<ApiKeyRecord | void>;
+  revoke(id: string, input?: { revokedAt?: Date }): Promise<void>;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,9 @@ export {
 export { isAuth, type AuthRequest } from './middleware/isAuth.js';
 export { hasRole, isSelfOrAdmin } from './middleware/hasRole.js';
 export { requireTenant, isSameTenant } from './middleware/tenant.js';
+export { isApiKey, type ApiKeyRequest } from './middleware/isApiKey.js';
+export type { ApiKeyRecord, ApiKeyRepo } from './core/ports/apiKey.repo.js';
+export { issueApiKey, verifyApiKey } from './utils/apiKey.js';
 export {
   AppError,
   EmailAlreadyExistsError,
@@ -69,13 +72,14 @@ export {
   type FieldValidationIssue,
 } from './utils/errorHandler.js';
 export {
+  makePrismaApiKeyRepo,
   makePrismaEmailVerificationTokenRepo,
   makePrismaOAuthAccountRepo,
   makePrismaPasswordResetTokenRepo,
   makePrismaRefreshTokenRepo,
   makePrismaUserRepo,
 } from './adapters/prisma.js';
-export { makeMemoryUserRepo } from './adapters/memory.js';
+export { makeMemoryApiKeyRepo, makeMemoryUserRepo } from './adapters/memory.js';
 
 import type { UserRepo } from './core/ports/user.repo.js';
 import type { AuthServiceDeps } from './modules/auth/auth.types.js';

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,3 +1,4 @@
 export { hasRole, isSelfOrAdmin } from './middleware/hasRole.js';
 export { isAuth, type AuthRequest } from './middleware/isAuth.js';
 export { requireTenant, isSameTenant } from './middleware/tenant.js';
+export { isApiKey, type ApiKeyRequest } from './middleware/isApiKey.js';

--- a/src/middleware/isApiKey.ts
+++ b/src/middleware/isApiKey.ts
@@ -1,0 +1,45 @@
+import type { Request, Response, NextFunction } from 'express';
+import type { ApiKeyRepo } from '../core/ports/apiKey.repo.js';
+import { verifyApiKey } from '../utils/apiKey.js';
+
+export type ApiKeyRequest = Request & {
+  apiKey?: { id: string; name?: string | null; scopes: string[]; tenantId?: string | number };
+};
+
+function extractKey(req: Request): string | null {
+  const headerKey = req.headers['x-api-key'];
+  if (typeof headerKey === 'string' && headerKey) return headerKey;
+
+  const auth = req.headers.authorization;
+  if (auth?.startsWith('ApiKey ')) return auth.slice('ApiKey '.length);
+
+  return null;
+}
+
+/**
+ * Authenticates machine-to-machine requests via an API key, read from the
+ * `X-API-Key` header or `Authorization: ApiKey <key>`. Attaches `req.apiKey`
+ * on success. Pass `requiredScopes` to also enforce scope membership.
+ */
+export function isApiKey(apiKeyRepo: ApiKeyRepo, options?: { requiredScopes?: string[] }) {
+  return async (req: ApiKeyRequest, res: Response, next: NextFunction) => {
+    const key = extractKey(req);
+    if (!key) {
+      return res.status(401).json({ error: { code: 'UNAUTHORIZED', message: 'Missing API key' } });
+    }
+
+    const [id] = key.split('.');
+    const record = id ? await apiKeyRepo.findById(id) : null;
+    if (!record || record.revokedAt || !verifyApiKey(key, record)) {
+      return res.status(401).json({ error: { code: 'UNAUTHORIZED', message: 'Invalid or revoked API key' } });
+    }
+
+    const scopes = record.scopes ?? [];
+    if (options?.requiredScopes?.length && options.requiredScopes.some((scope) => !scopes.includes(scope))) {
+      return res.status(403).json({ error: { code: 'FORBIDDEN', message: 'Missing required API key scope' } });
+    }
+
+    req.apiKey = { id: record.id, name: record.name, scopes, tenantId: record.tenantId ?? undefined };
+    return next();
+  };
+}

--- a/src/utils/apiKey.ts
+++ b/src/utils/apiKey.ts
@@ -1,0 +1,37 @@
+import { createHash, randomBytes, randomUUID, timingSafeEqual } from 'node:crypto';
+import type { ApiKeyRecord, ApiKeyRepo } from '../core/ports/apiKey.repo.js';
+
+function hashKey(key: string): string {
+  return createHash('sha256').update(key).digest('hex');
+}
+
+/**
+ * Generates a new API key, stores its hash via `apiKeyRepo.create`, and
+ * returns the plaintext key. The plaintext is only ever available here —
+ * only its hash is persisted, so store this return value immediately.
+ */
+export async function issueApiKey(
+  apiKeyRepo: ApiKeyRepo,
+  input: { name?: string | null; scopes?: string[]; tenantId?: string | number | null } = {},
+): Promise<{ id: string; key: string }> {
+  const id = randomUUID();
+  const secret = randomBytes(32).toString('base64url');
+  const key = `${id}.${secret}`;
+
+  await apiKeyRepo.create({
+    id,
+    name: input.name ?? null,
+    keyHash: hashKey(key),
+    scopes: input.scopes ?? [],
+    tenantId: input.tenantId ?? null,
+  });
+
+  return { id, key };
+}
+
+/** Verifies a plaintext API key against a stored record's hash using a constant-time comparison. */
+export function verifyApiKey(key: string, record: Pick<ApiKeyRecord, 'keyHash'>): boolean {
+  const expected = Buffer.from(record.keyHash);
+  const actual = Buffer.from(hashKey(key));
+  return expected.length === actual.length && timingSafeEqual(expected, actual);
+}

--- a/templates/init/prisma/schema.prisma
+++ b/templates/init/prisma/schema.prisma
@@ -94,3 +94,15 @@ enum Role {
   USER
   ADMIN
 }
+
+model ApiKey {
+  id        String    @id
+  name      String?
+  keyHash   String
+  scopes    String[]  @default([])
+  tenantId  String?
+  revokedAt DateTime?
+  createdAt DateTime  @default(now())
+
+  @@index([tenantId])
+}

--- a/tests/api-key-auth.test.mjs
+++ b/tests/api-key-auth.test.mjs
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+function makeRes() {
+  const res = {};
+  res.statusCode = 200;
+  res.status = (code) => { res.statusCode = code; return res; };
+  res.json = (body) => { res.body = body; return res; };
+  return res;
+}
+
+test('issueApiKey + isApiKey: valid key authenticates and attaches req.apiKey', async () => {
+  const { makeMemoryApiKeyRepo } = await import('../dist/adapters/memory.js');
+  const { issueApiKey } = await import('../dist/utils/apiKey.js');
+  const { isApiKey } = await import('../dist/middleware/isApiKey.js');
+
+  const apiKeyRepo = makeMemoryApiKeyRepo();
+  const { key } = await issueApiKey(apiKeyRepo, { name: 'billing-service', scopes: ['users:read'] });
+
+  const req = { headers: { 'x-api-key': key } };
+  const res = makeRes();
+  let nextCalled = false;
+
+  await isApiKey(apiKeyRepo)(req, res, () => { nextCalled = true; });
+
+  assert.equal(nextCalled, true);
+  assert.equal(req.apiKey.name, 'billing-service');
+  assert.deepEqual(req.apiKey.scopes, ['users:read']);
+});
+
+test('isApiKey rejects missing, malformed, and revoked keys', async () => {
+  const { makeMemoryApiKeyRepo } = await import('../dist/adapters/memory.js');
+  const { issueApiKey } = await import('../dist/utils/apiKey.js');
+  const { isApiKey } = await import('../dist/middleware/isApiKey.js');
+
+  const apiKeyRepo = makeMemoryApiKeyRepo();
+
+  const missing = makeRes();
+  await isApiKey(apiKeyRepo)({ headers: {} }, missing, () => assert.fail('should not call next'));
+  assert.equal(missing.statusCode, 401);
+
+  const malformed = makeRes();
+  await isApiKey(apiKeyRepo)({ headers: { 'x-api-key': 'not-a-valid-key' } }, malformed, () => assert.fail('should not call next'));
+  assert.equal(malformed.statusCode, 401);
+
+  const { id, key } = await issueApiKey(apiKeyRepo, {});
+  await apiKeyRepo.revoke(id);
+  const revoked = makeRes();
+  await isApiKey(apiKeyRepo)({ headers: { 'x-api-key': key } }, revoked, () => assert.fail('should not call next'));
+  assert.equal(revoked.statusCode, 401);
+});
+
+test('isApiKey enforces requiredScopes', async () => {
+  const { makeMemoryApiKeyRepo } = await import('../dist/adapters/memory.js');
+  const { issueApiKey } = await import('../dist/utils/apiKey.js');
+  const { isApiKey } = await import('../dist/middleware/isApiKey.js');
+
+  const apiKeyRepo = makeMemoryApiKeyRepo();
+  const { key } = await issueApiKey(apiKeyRepo, { scopes: ['users:read'] });
+
+  const res = makeRes();
+  await isApiKey(apiKeyRepo, { requiredScopes: ['users:write'] })(
+    { headers: { 'x-api-key': key } },
+    res,
+    () => assert.fail('should not call next'),
+  );
+  assert.equal(res.statusCode, 403);
+});


### PR DESCRIPTION
Closes #33.

## Summary
- `ApiKeyRepo` port (`findById`/`create`/`revoke`) + `ApiKeyRecord` type
- `issueApiKey(apiKeyRepo, input)` generates an `id.secret` key, persists only its SHA-256 hash, and returns the plaintext once
- `isApiKey(apiKeyRepo, { requiredScopes? })` middleware: reads `X-API-Key` or `Authorization: ApiKey <key>`, verifies via constant-time comparison, rejects missing/malformed/revoked keys and insufficient scopes, attaches `req.apiKey = { id, name, scopes, tenantId? }`
- `makeMemoryApiKeyRepo` and `makePrismaApiKeyRepo` adapters; new `ApiKey` model added to all three bundled Prisma schemas (`prisma/schema.prisma`, `templates/init`, `examples/express-prisma`)
- Exported from `my-crud-lib`, `my-crud-lib/middleware`, `my-crud-lib/adapter-memory`, `my-crud-lib/adapter-prisma`
- README: new "API Keys (Machine-to-Machine Auth)" section

## Test plan
- [x] `npm run build`
- [x] `npm test` (25/25 passing — 3 new tests: valid key, missing/malformed/revoked key rejection, scope enforcement)
- [x] `npm run ci` (full checklist incl. `npm pack --dry-run`)