### PR TITLE
feat: RS256/JWKS support for decentralized JWT verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,21 @@ The caller sends the key back via `X-API-Key: <key>` or `Authorization: ApiKey <
 
 To require either a user token or a service API key on the same route, chain your own small middleware that tries `isAuth` and falls back to `isApiKey`.
 
+## Asymmetric JWTs (RS256/JWKS)
+
+By default tokens are signed with `JWT_SECRET` (HS256), which every service that verifies tokens must also hold. For a microservices setup, sign with a private key in the auth service and let other services verify with the public key alone, via a standard JWKS endpoint:
+
+```bash
+JWT_ALG="RS256"
+JWT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
+JWT_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----"
+JWT_KEY_ID="2026-01"   # optional, defaults to "default"; bump when rotating keys
+```
+
+With `JWT_ALG=RS256`, `createLibrary`/`mountDefaultRoutes` automatically mount `GET /.well-known/jwks.json` (unprefixed, per convention) publishing the public key as a JWK. Other services can fetch it and verify tokens with any standard JWT/JWKS library — no shared secret required. `JWT_SECRET` is not needed in this mode.
+
+`JWT_PRIVATE_KEY`/`JWT_PUBLIC_KEY` accept PEM content directly, or with literal `\n` sequences (common when stored as a single-line CI/CD secret).
+
 ## Build Checks
 
 ```bash

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -12,3 +12,36 @@ export function getJwtSecret(): string {
   }
   return secret;
 }
+
+export type JwtAlgorithm = "HS256" | "RS256";
+
+/** `HS256` (default, shared secret) or `RS256` (asymmetric, for JWKS-based verification across services). */
+export function getJwtAlgorithm(): JwtAlgorithm {
+  return (process.env.JWT_ALG || "HS256").trim().toUpperCase() === "RS256" ? "RS256" : "HS256";
+}
+
+function normalizePemEnv(value: string): string {
+  // Supports keys stored with literal "\n" (common in .env files / CI secrets).
+  return value.includes("\\n") ? value.replace(/\\n/g, "\n") : value;
+}
+
+export function getJwtPrivateKey(): string {
+  const key = process.env.JWT_PRIVATE_KEY?.trim();
+  if (!key) {
+    throw new Error("JWT_PRIVATE_KEY is required when JWT_ALG=RS256");
+  }
+  return normalizePemEnv(key);
+}
+
+export function getJwtPublicKey(): string {
+  const key = process.env.JWT_PUBLIC_KEY?.trim();
+  if (!key) {
+    throw new Error("JWT_PUBLIC_KEY is required when JWT_ALG=RS256");
+  }
+  return normalizePemEnv(key);
+}
+
+/** Key id (`kid`) advertised in JWKS and stamped on RS256 tokens, so multiple keys can rotate side by side. */
+export function getJwtKeyId(): string {
+  return process.env.JWT_KEY_ID?.trim() || "default";
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ export type {
 } from './modules/user/user.types.js';
 export { createUserRouter } from './modules/user/user.controller.js';
 export { createAuthRouter } from './modules/auth/auth.controller.js';
+export { createJwksRouter } from './modules/jwks/jwks.controller.js';
+export { getJwks, type Jwk } from './utils/jwks.js';
 export { DEFAULT_REGISTER_ROLE, resolveRegisterRole } from './modules/auth/auth.defaults.js';
 export { makeAuthService } from './modules/auth/auth.service.js';
 export {
@@ -85,6 +87,8 @@ import type { UserRepo } from './core/ports/user.repo.js';
 import type { AuthServiceDeps } from './modules/auth/auth.types.js';
 import { createAuthRouter } from './modules/auth/auth.controller.js';
 import { createUserRouter } from './modules/user/user.controller.js';
+import { createJwksRouter } from './modules/jwks/jwks.controller.js';
+import { getJwtAlgorithm } from './config/env.js';
 
 /** Options for `createLibrary`/`mountDefaultRoutes`. */
 export type LibraryConfig = {
@@ -129,6 +133,11 @@ export function createLibrary(config: LibraryConfig, deps: LibraryDeps) {
 
   router.use(`${prefix}/auth`, createAuthRouter({ userRepo: deps.userRepo, ...config.auth }));
   router.use(`${prefix}/users`, createUserRouter({ userRepo: deps.userRepo }));
+
+  // JWKS is a well-known, unprefixed path by convention, and only meaningful with RS256.
+  if (getJwtAlgorithm() === 'RS256') {
+    router.use(createJwksRouter());
+  }
 
   return { router };
 }

--- a/src/modules/jwks/jwks.controller.ts
+++ b/src/modules/jwks/jwks.controller.ts
@@ -1,0 +1,13 @@
+import { Router } from 'express';
+import { getJwks } from '../../utils/jwks.js';
+
+/** Exposes `GET /.well-known/jwks.json` so other services can verify RS256 tokens without sharing a secret. */
+export function createJwksRouter() {
+  const router = Router();
+
+  router.get('/.well-known/jwks.json', (_req, res) => {
+    res.json(getJwks());
+  });
+
+  return router;
+}

--- a/src/utils/jwks.ts
+++ b/src/utils/jwks.ts
@@ -1,0 +1,26 @@
+import { createPublicKey } from "node:crypto";
+import { getJwtAlgorithm, getJwtKeyId, getJwtPublicKey } from "../config/env.js";
+
+export type Jwk = Record<string, unknown>;
+
+/**
+ * Builds a JWKS document from `JWT_PUBLIC_KEY`. Returns an empty key set
+ * when `JWT_ALG` is not `RS256` (HS256 has no public key to publish).
+ */
+export function getJwks(): { keys: Jwk[] } {
+  if (getJwtAlgorithm() !== "RS256") return { keys: [] };
+
+  const keyObject = createPublicKey(getJwtPublicKey());
+  const jwk = keyObject.export({ format: "jwk" }) as Record<string, unknown>;
+
+  return {
+    keys: [
+      {
+        ...jwk,
+        use: "sig",
+        alg: "RS256",
+        kid: getJwtKeyId(),
+      },
+    ],
+  };
+}

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -1,5 +1,13 @@
-import jwt, { type SignOptions } from "jsonwebtoken";
-import { getJwtSecret, JWT_ACCESS_EXPIRES_IN, JWT_REFRESH_EXPIRES_IN } from "../config/env.js";
+import jwt, { type SignOptions, type VerifyOptions } from "jsonwebtoken";
+import {
+  getJwtAlgorithm,
+  getJwtKeyId,
+  getJwtPrivateKey,
+  getJwtPublicKey,
+  getJwtSecret,
+  JWT_ACCESS_EXPIRES_IN,
+  JWT_REFRESH_EXPIRES_IN,
+} from "../config/env.js";
 
 export type JwtPayload = {
   sub: number | string;
@@ -10,18 +18,31 @@ export type JwtPayload = {
   tenantId?: number | string;
 };
 
+function getSigningKey(): string {
+  return getJwtAlgorithm() === "RS256" ? getJwtPrivateKey() : getJwtSecret();
+}
+
+function getVerifyingKey(): string {
+  return getJwtAlgorithm() === "RS256" ? getJwtPublicKey() : getJwtSecret();
+}
+
+function signOptions(expiresIn: string): SignOptions {
+  const algorithm = getJwtAlgorithm();
+  return {
+    expiresIn,
+    algorithm,
+    ...(algorithm === "RS256" ? { keyid: getJwtKeyId() } : {}),
+  } as SignOptions;
+}
+
 export function signAccessToken(payload: JwtPayload): string {
-  return jwt.sign(payload, getJwtSecret(), {
-    expiresIn: JWT_ACCESS_EXPIRES_IN,
-  } as SignOptions);
+  return jwt.sign(payload, getSigningKey(), signOptions(JWT_ACCESS_EXPIRES_IN));
 }
 
 export function signRefreshToken(payload: JwtPayload): string {
-  return jwt.sign({ ...payload, typ: "refresh" }, getJwtSecret(), {
-    expiresIn: JWT_REFRESH_EXPIRES_IN,
-  } as SignOptions);
+  return jwt.sign({ ...payload, typ: "refresh" }, getSigningKey(), signOptions(JWT_REFRESH_EXPIRES_IN));
 }
 
 export function verifyToken<T = JwtPayload>(token: string): T {
-  return jwt.verify(token, getJwtSecret()) as T;
+  return jwt.verify(token, getVerifyingKey(), { algorithms: [getJwtAlgorithm()] } as VerifyOptions) as T;
 }

--- a/tests/jwks.test.mjs
+++ b/tests/jwks.test.mjs
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { generateKeyPairSync, createPublicKey } from 'node:crypto';
+
+test('RS256: tokens signed with the private key verify against the public key, and JWKS matches', async () => {
+  const { publicKey, privateKey } = generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+
+  process.env.JWT_ALG = 'RS256';
+  process.env.JWT_PRIVATE_KEY = privateKey;
+  process.env.JWT_PUBLIC_KEY = publicKey;
+  process.env.JWT_KEY_ID = 'test-key-1';
+
+  try {
+    const { signAccessToken, verifyToken } = await import('../dist/utils/jwt.js');
+    const { getJwks } = await import('../dist/utils/jwks.js');
+
+    const token = signAccessToken({ sub: 42, role: 'USER' });
+    const payload = verifyToken(token);
+    assert.equal(payload.sub, 42);
+    assert.equal(payload.role, 'USER');
+
+    const jwks = getJwks();
+    assert.equal(jwks.keys.length, 1);
+    assert.equal(jwks.keys[0].kid, 'test-key-1');
+    assert.equal(jwks.keys[0].kty, 'RSA');
+
+    // Confirm the published JWK actually matches the signing key's modulus/exponent.
+    const expectedJwk = createPublicKey(publicKey).export({ format: 'jwk' });
+    assert.equal(jwks.keys[0].n, expectedJwk.n);
+    assert.equal(jwks.keys[0].e, expectedJwk.e);
+  } finally {
+    delete process.env.JWT_ALG;
+    delete process.env.JWT_PRIVATE_KEY;
+    delete process.env.JWT_PUBLIC_KEY;
+    delete process.env.JWT_KEY_ID;
+  }
+});
+
+test('JWKS is empty when JWT_ALG is not RS256', async () => {
+  delete process.env.JWT_ALG;
+  const { getJwks } = await import('../dist/utils/jwks.js');
+  assert.deepEqual(getJwks(), { keys: [] });
+});


### PR DESCRIPTION
Closes #34.

## Summary
- `JWT_ALG` env var (`HS256` default, or `RS256`) selects the signing algorithm.
- RS256 mode signs with `JWT_PRIVATE_KEY` and verifies with `JWT_PUBLIC_KEY`; `JWT_KEY_ID` (default `"default"`) is stamped as `kid` on tokens and in the JWKS document, for key rotation.
- `getJwks()` converts the public key to a JWK via Node's built-in `KeyObject.export({ format: 'jwk' })` — no new dependency.
- `createJwksRouter()` exposes `GET /.well-known/jwks.json`; `createLibrary`/`mountDefaultRoutes` mount it automatically (unprefixed, per convention) when `JWT_ALG=RS256`.
- HS256 remains the default; `JWT_SECRET`-based apps are completely unaffected.

## Test plan
- [x] `npm run build`
- [x] `npm test` (27/27 passing — 2 new tests: RS256 sign/verify round-trip with a generated key pair verified against the published JWKS, and JWKS is empty under HS256)
- [x] `npm run ci` (full checklist incl. `npm pack --dry-run`)