### PR TITLE
feat: idempotency key support for POST register/create

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,24 @@ With `JWT_ALG=RS256`, `createLibrary`/`mountDefaultRoutes` automatically mount `
 
 `JWT_PRIVATE_KEY`/`JWT_PUBLIC_KEY` accept PEM content directly, or with literal `\n` sequences (common when stored as a single-line CI/CD secret).
 
+## Idempotency Keys
+
+For clients that retry on timeout or fire the same intent from multiple parallel callers (common with async workers and microservice retries), `POST /auth/register` and `POST /users` can replay a stored response instead of running twice:
+
+```ts
+import { createLibrary, createServer } from "my-crud-lib";
+import { makeMemoryIdempotencyStore } from "my-crud-lib/adapters/memory"; // or makePrismaIdempotencyStore
+
+const app = createServer();
+const lib = createLibrary(
+  { routesPrefix: "/api" },
+  { userRepo, idempotencyStore: makeMemoryIdempotencyStore() }
+);
+app.use(lib.router);
+```
+
+Send `Idempotency-Key: <uuid>` on the request. The first call runs normally and its response is stored; any repeat with the same key returns the exact same response (marked with an `Idempotent-Replay: true` header) without re-executing the handler. Requests without the header are unaffected — idempotency is opt-in per call. The `idempotent(store, options?)` middleware is also exported standalone for use on your own routes.
+
 ## Build Checks
 
 ```bash

--- a/examples/express-prisma/prisma/schema.prisma
+++ b/examples/express-prisma/prisma/schema.prisma
@@ -106,3 +106,11 @@ model ApiKey {
 
   @@index([tenantId])
 }
+
+model IdempotencyKey {
+  key       String    @id
+  status    Int
+  body      Json
+  expiresAt DateTime?
+  createdAt DateTime  @default(now())
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -106,3 +106,11 @@ model ApiKey {
 
   @@index([tenantId])
 }
+
+model IdempotencyKey {
+  key       String    @id
+  status    Int
+  body      Json
+  expiresAt DateTime?
+  createdAt DateTime  @default(now())
+}

--- a/src/adapter-memory.ts
+++ b/src/adapter-memory.ts
@@ -1,1 +1,1 @@
-export { makeMemoryApiKeyRepo, makeMemoryUserRepo } from './adapters/memory.js';
+export { makeMemoryApiKeyRepo, makeMemoryIdempotencyStore, makeMemoryUserRepo } from './adapters/memory.js';

--- a/src/adapter-prisma.ts
+++ b/src/adapter-prisma.ts
@@ -1,6 +1,7 @@
 export {
   makePrismaApiKeyRepo,
   makePrismaEmailVerificationTokenRepo,
+  makePrismaIdempotencyStore,
   makePrismaOAuthAccountRepo,
   makePrismaPasswordResetTokenRepo,
   makePrismaRefreshTokenRepo,

--- a/src/adapters/memory.ts
+++ b/src/adapters/memory.ts
@@ -1,5 +1,6 @@
 import type { UserRepo } from '../core/ports/user.repo.js';
 import type { ApiKeyRecord, ApiKeyRepo } from '../core/ports/apiKey.repo.js';
+import type { IdempotencyRecord, IdempotencyStore } from '../core/ports/idempotency.repo.js';
 import type { AdminUpdateUserInput, Role, UserListItem } from '../modules/user/user.types.js';
 
 type StoredUser = UserListItem & { passwordHash: string };
@@ -158,6 +159,30 @@ export function makeMemoryApiKeyRepo(): ApiKeyRepo {
       const record = keys.get(id);
       if (!record) return;
       keys.set(id, { ...record, revokedAt: input.revokedAt ?? new Date() });
+    },
+  };
+}
+
+/** In-memory `IdempotencyStore` implementation. Useful for demos, prototyping, and tests. */
+export function makeMemoryIdempotencyStore(): IdempotencyStore {
+  const records = new Map<string, IdempotencyRecord & { expiresAt: number | null }>();
+
+  return {
+    async get(key) {
+      const record = records.get(key);
+      if (!record) return null;
+      if (record.expiresAt !== null && record.expiresAt <= Date.now()) {
+        records.delete(key);
+        return null;
+      }
+      return { status: record.status, body: record.body };
+    },
+
+    async set(key, record, ttlMs) {
+      records.set(key, {
+        ...record,
+        expiresAt: ttlMs !== undefined ? Date.now() + ttlMs : null,
+      });
     },
   };
 }

--- a/src/adapters/prisma.ts
+++ b/src/adapters/prisma.ts
@@ -1,6 +1,7 @@
 import type { Prisma, PrismaClient } from '@prisma/client';
 import type { UserRepo } from '../core/ports/user.repo.js';
 import type { ApiKeyRepo } from '../core/ports/apiKey.repo.js';
+import type { IdempotencyStore } from '../core/ports/idempotency.repo.js';
 import type {
   EmailVerificationTokenRepo,
   OAuthAccountRepo,
@@ -324,6 +325,27 @@ export function makePrismaApiKeyRepo(prisma: PrismaClient): ApiKeyRepo {
       await (prisma as any).apiKey.update({
         where: { id },
         data: { revokedAt: dateOrNow(input.revokedAt) },
+      });
+    },
+  };
+}
+
+/** `IdempotencyStore` implementation; pass it to the `idempotent` middleware to persist replayed responses across instances. */
+export function makePrismaIdempotencyStore(prisma: PrismaClient): IdempotencyStore {
+  return {
+    async get(key) {
+      const record = await (prisma as any).idempotencyKey.findUnique({ where: { key } });
+      if (!record) return null;
+      if (record.expiresAt && record.expiresAt.getTime() <= Date.now()) return null;
+      return { status: record.status, body: record.body };
+    },
+
+    async set(key, record, ttlMs) {
+      const expiresAt = ttlMs !== undefined ? new Date(Date.now() + ttlMs) : null;
+      await (prisma as any).idempotencyKey.upsert({
+        where: { key },
+        create: { key, status: record.status, body: record.body as any, expiresAt },
+        update: { status: record.status, body: record.body as any, expiresAt },
       });
     },
   };

--- a/src/core/ports/idempotency.repo.ts
+++ b/src/core/ports/idempotency.repo.ts
@@ -1,0 +1,14 @@
+export type IdempotencyRecord = {
+  status: number;
+  body: unknown;
+};
+
+/**
+ * Storage port for idempotency keys, used by the `idempotent` middleware to
+ * replay a stored response instead of re-running a handler for a repeated
+ * request (retries, concurrent duplicate calls from other services).
+ */
+export interface IdempotencyStore {
+  get(key: string): Promise<IdempotencyRecord | null>;
+  set(key: string, record: IdempotencyRecord, ttlMs?: number): Promise<void>;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,8 @@ export { requireTenant, isSameTenant } from './middleware/tenant.js';
 export { isApiKey, type ApiKeyRequest } from './middleware/isApiKey.js';
 export type { ApiKeyRecord, ApiKeyRepo } from './core/ports/apiKey.repo.js';
 export { issueApiKey, verifyApiKey } from './utils/apiKey.js';
+export { idempotent } from './middleware/idempotent.js';
+export type { IdempotencyRecord, IdempotencyStore } from './core/ports/idempotency.repo.js';
 export {
   AppError,
   EmailAlreadyExistsError,
@@ -76,15 +78,17 @@ export {
 export {
   makePrismaApiKeyRepo,
   makePrismaEmailVerificationTokenRepo,
+  makePrismaIdempotencyStore,
   makePrismaOAuthAccountRepo,
   makePrismaPasswordResetTokenRepo,
   makePrismaRefreshTokenRepo,
   makePrismaUserRepo,
 } from './adapters/prisma.js';
-export { makeMemoryApiKeyRepo, makeMemoryUserRepo } from './adapters/memory.js';
+export { makeMemoryApiKeyRepo, makeMemoryIdempotencyStore, makeMemoryUserRepo } from './adapters/memory.js';
 
 import type { UserRepo } from './core/ports/user.repo.js';
 import type { AuthServiceDeps } from './modules/auth/auth.types.js';
+import type { IdempotencyStore } from './core/ports/idempotency.repo.js';
 import { createAuthRouter } from './modules/auth/auth.controller.js';
 import { createUserRouter } from './modules/user/user.controller.js';
 import { createJwksRouter } from './modules/jwks/jwks.controller.js';
@@ -101,6 +105,8 @@ export type LibraryConfig = {
 /** Dependencies for `createLibrary`/`mountDefaultRoutes`. */
 export type LibraryDeps = {
   userRepo: UserRepo;
+  /** Enables `Idempotency-Key` support on `POST /auth/register` and `POST /users`. */
+  idempotencyStore?: IdempotencyStore;
 };
 
 function normalizePrefix(prefix?: string): string {
@@ -131,8 +137,11 @@ export function createLibrary(config: LibraryConfig, deps: LibraryDeps) {
   const router = Router();
   const prefix = normalizePrefix(config.routesPrefix);
 
-  router.use(`${prefix}/auth`, createAuthRouter({ userRepo: deps.userRepo, ...config.auth }));
-  router.use(`${prefix}/users`, createUserRouter({ userRepo: deps.userRepo }));
+  router.use(
+    `${prefix}/auth`,
+    createAuthRouter({ userRepo: deps.userRepo, idempotencyStore: deps.idempotencyStore, ...config.auth }),
+  );
+  router.use(`${prefix}/users`, createUserRouter({ userRepo: deps.userRepo, idempotencyStore: deps.idempotencyStore }));
 
   // JWKS is a well-known, unprefixed path by convention, and only meaningful with RS256.
   if (getJwtAlgorithm() === 'RS256') {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,3 +2,4 @@ export { hasRole, isSelfOrAdmin } from './middleware/hasRole.js';
 export { isAuth, type AuthRequest } from './middleware/isAuth.js';
 export { requireTenant, isSameTenant } from './middleware/tenant.js';
 export { isApiKey, type ApiKeyRequest } from './middleware/isApiKey.js';
+export { idempotent } from './middleware/idempotent.js';

--- a/src/middleware/idempotent.ts
+++ b/src/middleware/idempotent.ts
@@ -1,0 +1,35 @@
+import type { Request, Response, NextFunction } from 'express';
+import type { IdempotencyStore } from '../core/ports/idempotency.repo.js';
+
+/**
+ * Replays a stored response for repeated requests carrying the same
+ * `Idempotency-Key` header, instead of re-running the handler. Requests
+ * without the header pass through unaffected — idempotency is opt-in per
+ * call, not enforced on every request.
+ */
+export function idempotent(store: IdempotencyStore, options?: { headerName?: string; ttlMs?: number }) {
+  const headerName = (options?.headerName ?? 'idempotency-key').toLowerCase();
+  const ttlMs = options?.ttlMs;
+
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const raw = req.headers[headerName];
+    const key = Array.isArray(raw) ? raw[0] : raw;
+    if (!key) return next();
+
+    const existing = await store.get(key);
+    if (existing) {
+      res.setHeader('Idempotent-Replay', 'true');
+      return res.status(existing.status).json(existing.body);
+    }
+
+    const originalJson = res.json.bind(res);
+    res.json = ((body: unknown) => {
+      store.set(key, { status: res.statusCode, body }, ttlMs).catch((err) => {
+        console.error('[my-crud-lib] failed to persist idempotency record:', err);
+      });
+      return originalJson(body);
+    }) as Response['json'];
+
+    return next();
+  };
+}

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,6 +1,8 @@
 import { Router, type Request, type Response } from 'express';
 import { isAuth, type AuthRequest } from '../../middleware/isAuth.js';
+import { idempotent } from '../../middleware/idempotent.js';
 import { sendAppError } from '../../utils/errorHandler.js';
+import type { IdempotencyStore } from '../../core/ports/idempotency.repo.js';
 import {
   emailVerificationConfirmSchema,
   emailVerificationRequestSchema,
@@ -12,17 +14,23 @@ import {
 import { makeAuthService } from './auth.service.js';
 import type { AuthServiceDeps } from './auth.types.js';
 
+export type AuthRouterDeps = AuthServiceDeps & {
+  /** Enables `Idempotency-Key` support on `POST /register` when provided. */
+  idempotencyStore?: IdempotencyStore;
+};
+
 /**
  * Builds the auth router: register, login, refresh, logout, password reset,
  * email verification, and `GET /me`. Password reset, email verification, and
  * OAuth linking are only active when their corresponding repo/callback deps
  * are provided; otherwise those routes respond with `NotConfiguredError`.
  */
-export function createAuthRouter(deps: AuthServiceDeps) {
+export function createAuthRouter(deps: AuthRouterDeps) {
   const router = Router();
   const service = makeAuthService(deps);
+  const registerMiddleware = deps.idempotencyStore ? [idempotent(deps.idempotencyStore)] : [];
 
-  router.post('/register', async (req: Request, res: Response) => {
+  router.post('/register', ...registerMiddleware, async (req: Request, res: Response) => {
     try {
       const data = registerSchema.parse(req.body);
       const result = await service.registerUser(data);

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { isAuth, type AuthRequest } from '../../middleware/isAuth.js';
 import { hasRole, isSelfOrAdmin } from '../../middleware/hasRole.js';
+import { idempotent } from '../../middleware/idempotent.js';
 import { ForbiddenError, sendAppError } from '../../utils/errorHandler.js';
 import {
   listUsersQuerySchema,
@@ -10,15 +11,23 @@ import {
 } from './user.schemas.js';
 import { makeUserService } from './user.service.js';
 import type { UserRepo } from '../../core/ports/user.repo.js';
+import type { IdempotencyStore } from '../../core/ports/idempotency.repo.js';
+
+export type UserRouterDeps = {
+  userRepo: UserRepo;
+  /** Enables `Idempotency-Key` support on `POST /` (admin create) when provided. */
+  idempotencyStore?: IdempotencyStore;
+};
 
 /**
  * Builds the user CRUD router: admin list/create/update/delete plus
  * `GET/PUT /me` for the authenticated user. Admin routes require an
  * `ADMIN` bearer token; `/:id` routes allow the resource owner or an admin.
  */
-export function createUserRouter(deps: { userRepo: UserRepo }) {
+export function createUserRouter(deps: UserRouterDeps) {
   const router = Router();
   const service = makeUserService({ userRepo: deps.userRepo });
+  const createMiddleware = deps.idempotencyStore ? [idempotent(deps.idempotencyStore)] : [];
 
   router.get('/', isAuth, hasRole('ADMIN'), async (req: AuthRequest, res) => {
     try {
@@ -48,7 +57,7 @@ export function createUserRouter(deps: { userRepo: UserRepo }) {
     }
   });
 
-  router.post('/', isAuth, hasRole('ADMIN'), async (req, res) => {
+  router.post('/', isAuth, hasRole('ADMIN'), ...createMiddleware, async (req, res) => {
     try {
       const body = adminCreateUserSchema.parse(req.body);
       const data = await service.adminCreateUser(body);

--- a/templates/init/prisma/schema.prisma
+++ b/templates/init/prisma/schema.prisma
@@ -106,3 +106,11 @@ model ApiKey {
 
   @@index([tenantId])
 }
+
+model IdempotencyKey {
+  key       String    @id
+  status    Int
+  body      Json
+  expiresAt DateTime?
+  createdAt DateTime  @default(now())
+}

--- a/tests/idempotency.test.mjs
+++ b/tests/idempotency.test.mjs
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+function makeRes() {
+  const res = {};
+  res.statusCode = 200;
+  res.headers = {};
+  res.status = (code) => { res.statusCode = code; return res; };
+  res.setHeader = (name, value) => { res.headers[name] = value; };
+  res.json = (body) => { res.body = body; return res; };
+  return res;
+}
+
+test('idempotent middleware replays the stored response for a repeated key without re-running the handler', async () => {
+  const { makeMemoryIdempotencyStore } = await import('../dist/adapters/memory.js');
+  const { idempotent } = await import('../dist/middleware/idempotent.js');
+
+  const store = makeMemoryIdempotencyStore();
+  const middleware = idempotent(store);
+
+  let handlerCalls = 0;
+  const handler = (req, res) => {
+    handlerCalls += 1;
+    res.status(201).json({ id: handlerCalls });
+  };
+
+  const req = { headers: { 'idempotency-key': 'key-1' } };
+
+  const res1 = makeRes();
+  await middleware(req, res1, () => handler(req, res1));
+  assert.equal(handlerCalls, 1);
+  assert.deepEqual(res1.body, { id: 1 });
+
+  // Give the fire-and-forget store.set a tick to complete before replaying.
+  await new Promise((resolve) => setImmediate(resolve));
+
+  const res2 = makeRes();
+  await middleware(req, res2, () => handler(req, res2));
+  assert.equal(handlerCalls, 1, 'handler must not run again for a repeated idempotency key');
+  assert.deepEqual(res2.body, { id: 1 });
+  assert.equal(res2.statusCode, 201);
+  assert.equal(res2.headers['Idempotent-Replay'], 'true');
+});
+
+test('idempotent middleware passes through requests without the header', async () => {
+  const { makeMemoryIdempotencyStore } = await import('../dist/adapters/memory.js');
+  const { idempotent } = await import('../dist/middleware/idempotent.js');
+
+  const store = makeMemoryIdempotencyStore();
+  const middleware = idempotent(store);
+
+  let handlerCalls = 0;
+  const req = { headers: {} };
+  const res = makeRes();
+
+  await middleware(req, res, () => { handlerCalls += 1; res.status(200).json({ ok: true }); });
+  await middleware(req, res, () => { handlerCalls += 1; res.status(200).json({ ok: true }); });
+
+  assert.equal(handlerCalls, 2, 'handler runs every time when no idempotency key is sent');
+});
+
+test('memory idempotency store expires records after ttlMs', async () => {
+  const { makeMemoryIdempotencyStore } = await import('../dist/adapters/memory.js');
+
+  const store = makeMemoryIdempotencyStore();
+  await store.set('short-lived', { status: 200, body: { ok: true } }, 10);
+
+  const immediate = await store.get('short-lived');
+  assert.ok(immediate);
+
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  const afterExpiry = await store.get('short-lived');
+  assert.equal(afterExpiry, null);
+});


### PR DESCRIPTION
Closes #35.

## Summary
- `IdempotencyStore` port (`get`/`set` with optional TTL) + `idempotent(store, options?)` middleware
- Reads `Idempotency-Key` (header name configurable) — absent header is a pure pass-through, present header replays the stored `{ status, body }` on repeat instead of re-running the handler, tagging replays with `Idempotent-Replay: true`
- `createAuthRouter`/`createUserRouter` accept an optional `idempotencyStore` dep, applied to `POST /auth/register` and admin `POST /users`; `LibraryDeps.idempotencyStore` threads it through `createLibrary`/`mountDefaultRoutes`
- `makeMemoryIdempotencyStore` (TTL-aware, lazy expiry) and `makePrismaIdempotencyStore` (new `IdempotencyKey` model, `body Json`, added to all three bundled Prisma schemas)
- Exported from `my-crud-lib`, `my-crud-lib/middleware`, `my-crud-lib/adapter-memory`, `my-crud-lib/adapter-prisma`

## Test plan
- [x] `npm run build`
- [x] `npm test` (30/30 passing — 3 new tests: replay without re-running the handler, pass-through without the header, TTL expiry)
- [x] `npm run ci` (full checklist incl. `npm pack --dry-run`)