### PR TITLE
feat: bulk user lookup (findManyByIds, POST /users/batch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,24 @@ app.use(lib.router);
 
 Send `Idempotency-Key: <uuid>` on the request. The first call runs normally and its response is stored; any repeat with the same key returns the exact same response (marked with an `Idempotent-Replay: true` header) without re-executing the handler. Requests without the header are unaffected — idempotency is opt-in per call. The `idempotent(store, options?)` middleware is also exported standalone for use on your own routes.
 
+## Bulk User Lookup
+
+`POST /users/batch` resolves multiple users in a single call, for services that would otherwise fire N parallel `GET /users/:id` requests:
+
+```http
+POST /users/batch
+Authorization: Bearer <admin accessToken>
+Content-Type: application/json
+
+{ "ids": [1, 2, 3] }
+```
+
+```json
+{ "items": [ { "id": 1, "email": "...", ... }, { "id": 2, "email": "...", ... } ] }
+```
+
+Unmatched ids are silently omitted rather than causing an error. Requires an `ADMIN` token and, like `GET /users`, is automatically scoped to the admin's `tenantId` when present. Accepts up to 100 ids per call. `UserRepo.findManyByIds` is optional on custom adapters — when absent, the service falls back to N `findById` calls, so existing adapters keep working unchanged.
+
 ## Build Checks
 
 ```bash

--- a/src/adapters/memory.ts
+++ b/src/adapters/memory.ts
@@ -54,6 +54,11 @@ export function makeMemoryUserRepo(): UserRepo {
       return user ? toPublic(user) : null;
     },
 
+    async findManyByIds(ids) {
+      const wanted = new Set(ids.map((id) => Number(id)));
+      return [...users.values()].filter((u) => wanted.has(Number(u.id))).map(toPublic);
+    },
+
     async findByEmail(email) {
       const user = [...users.values()].find((u) => u.email === email);
       return user ? { ...toPublic(user), passwordHash: user.passwordHash } : null;

--- a/src/adapters/prisma.ts
+++ b/src/adapters/prisma.ts
@@ -76,6 +76,23 @@ export function makePrismaUserRepo(prisma: PrismaClient): UserRepo {
       }) as any;
     },
 
+    async findManyByIds(ids) {
+      const users = await prisma.user.findMany({
+        where: { id: { in: ids as any } },
+        select: {
+          id: true,
+          email: true,
+          name: true,
+          role: true,
+          tenantId: true,
+          createdAt: true,
+          updatedAt: true,
+          profile: { select: { bio: true, avatarUrl: true } },
+        },
+      });
+      return users as unknown as UserListItem[];
+    },
+
     async findByEmail(email) {
       return prisma.user.findUnique({
         where: { email },

--- a/src/core/ports/user.repo.ts
+++ b/src/core/ports/user.repo.ts
@@ -21,6 +21,12 @@ export interface UserRepo {
   findById(id: number | string): Promise<UserListItem | null>;
   /** Must include `passwordHash` so the auth service can verify credentials. */
   findByEmail(email: string): Promise<UserListItem & { passwordHash?: string } | null>;
+  /**
+   * Resolves multiple users in one call, to avoid N+1/N-parallel lookups
+   * across services. Returns only the users found; unmatched ids are
+   * silently omitted. Optional — falls back to N `findById` calls when absent.
+   */
+  findManyByIds?(ids: Array<number | string>): Promise<UserListItem[]>;
   create(input: { email: string; passwordHash: string; name?: string | null; role?: string; bio?: string | null; avatarUrl?: string | null; tenantId?: string | number | null }): Promise<UserListItem>;
   update(id: number | string, input: AdminUpdateUserInput): Promise<UserListItem>;
   delete(id: number | string): Promise<void>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,7 @@ export {
   adminUpdateUserSchema,
   listUsersQuerySchema,
   updateMeSchema,
+  userIdsBatchSchema,
 } from './modules/user/user.schemas.js';
 export { isAuth, type AuthRequest } from './middleware/isAuth.js';
 export { hasRole, isSelfOrAdmin } from './middleware/hasRole.js';

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -8,6 +8,7 @@ import {
   updateMeSchema,
   adminCreateUserSchema,
   adminUpdateUserSchema,
+  userIdsBatchSchema,
 } from './user.schemas.js';
 import { makeUserService } from './user.service.js';
 import type { UserRepo } from '../../core/ports/user.repo.js';
@@ -62,6 +63,16 @@ export function createUserRouter(deps: UserRouterDeps) {
       const body = adminCreateUserSchema.parse(req.body);
       const data = await service.adminCreateUser(body);
       res.status(201).json(data);
+    } catch (err) {
+      sendAppError(res, err);
+    }
+  });
+
+  router.post('/batch', isAuth, hasRole('ADMIN'), async (req: AuthRequest, res) => {
+    try {
+      const { ids } = userIdsBatchSchema.parse(req.body);
+      const data = await service.getUsersByIds(ids, req.user!.tenantId);
+      res.json({ items: data });
     } catch (err) {
       sendAppError(res, err);
     }

--- a/src/modules/user/user.schemas.ts
+++ b/src/modules/user/user.schemas.ts
@@ -47,7 +47,12 @@ export const adminUpdateUserSchema = z.object({
   avatarUrl: z.string().url().nullish(),
 });
 
+export const userIdsBatchSchema = z.object({
+  ids: z.array(z.union([z.string(), z.number()])).min(1).max(100),
+});
+
 export type ListUsersQuery = z.infer<typeof listUsersQuerySchema>;
+export type UserIdsBatchInput = z.infer<typeof userIdsBatchSchema>;
 export type UpdateMeInput = z.infer<typeof updateMeSchema>;
 export type AdminCreateUserInput = z.infer<typeof adminCreateUserSchema>;
 export type AdminUpdateUserInput = z.infer<typeof adminUpdateUserSchema>;

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -41,6 +41,17 @@ export function makeUserService(deps: { userRepo: UserRepo }) {
       return user;
     },
 
+    /** Resolves multiple users in one call. Uses `UserRepo.findManyByIds` when the adapter supports it, otherwise falls back to N `findById` calls. */
+    async getUsersByIds(ids: Array<number | string>, tenantId?: string | number): Promise<UserListItem[]> {
+      const users = userRepo.findManyByIds
+        ? await userRepo.findManyByIds(ids)
+        : (await Promise.all(ids.map((id) => userRepo.findById(id)))).filter((u): u is UserListItem => u !== null);
+
+      return tenantId === undefined
+        ? users
+        : users.filter((u) => String(u.tenantId ?? '') === String(tenantId));
+    },
+
     updateMe(userId: number | string, data: UpdateMeInput) {
       return userRepo.updateMe(userId, data);
     },

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -12,4 +12,5 @@ export {
   adminUpdateUserSchema,
   listUsersQuerySchema,
   updateMeSchema,
+  userIdsBatchSchema,
 } from './modules/user/user.schemas.js';

--- a/tests/bulk-lookup.test.mjs
+++ b/tests/bulk-lookup.test.mjs
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+test('userRepo.findManyByIds resolves multiple users in one call, skipping unmatched ids', async () => {
+  const { makeMemoryUserRepo } = await import('../dist/adapters/memory.js');
+
+  const repo = makeMemoryUserRepo();
+  const a = await repo.create({ email: 'a@example.com', passwordHash: 'x' });
+  const b = await repo.create({ email: 'b@example.com', passwordHash: 'x' });
+  await repo.create({ email: 'c@example.com', passwordHash: 'x' });
+
+  const found = await repo.findManyByIds([a.id, b.id, 9999]);
+  const emails = found.map((u) => u.email).sort();
+  assert.deepEqual(emails, ['a@example.com', 'b@example.com']);
+});
+
+test('userService.getUsersByIds falls back to N findById calls when findManyByIds is absent', async () => {
+  const { makeUserService } = await import('../dist/modules/user/user.service.js');
+
+  const store = new Map();
+  let findManyByIdsCalls = 0;
+  const userRepo = {
+    async findById(id) {
+      return store.get(String(id)) ?? null;
+    },
+    // findManyByIds intentionally omitted
+  };
+
+  store.set('1', { id: 1, email: 'a@example.com', name: null, role: 'USER', createdAt: '', updatedAt: '' });
+  store.set('2', { id: 2, email: 'b@example.com', name: null, role: 'USER', createdAt: '', updatedAt: '' });
+
+  const service = makeUserService({ userRepo });
+  const result = await service.getUsersByIds([1, 2, 3]);
+
+  assert.equal(findManyByIdsCalls, 0);
+  assert.equal(result.length, 2);
+  assert.deepEqual(result.map((u) => u.email).sort(), ['a@example.com', 'b@example.com']);
+});
+
+test('userService.getUsersByIds scopes results to tenantId when provided', async () => {
+  const { makeMemoryUserRepo } = await import('../dist/adapters/memory.js');
+  const { makeUserService } = await import('../dist/modules/user/user.service.js');
+
+  const userRepo = makeMemoryUserRepo();
+  const a = await userRepo.create({ email: 'a@tenant-a.com', passwordHash: 'x', tenantId: 'tenant-a' });
+  const b = await userRepo.create({ email: 'b@tenant-b.com', passwordHash: 'x', tenantId: 'tenant-b' });
+
+  const service = makeUserService({ userRepo });
+  const result = await service.getUsersByIds([a.id, b.id], 'tenant-a');
+
+  assert.equal(result.length, 1);
+  assert.equal(result[0].email, 'a@tenant-a.com');
+});


### PR DESCRIPTION
Closes #36.

## Summary
- `UserRepo.findManyByIds?(ids)` — optional, implemented by both `makeMemoryUserRepo` and `makePrismaUserRepo` (via `WHERE id IN (...)`)
- `userService.getUsersByIds(ids, tenantId?)` — uses `findManyByIds` when available, otherwise falls back to N `findById` calls, so custom `UserRepo` adapters that don't implement it keep working unchanged
- `POST /users/batch` (admin-only, `{ ids: [...] }`, up to 100 per call) returns `{ items: UserListItem[] }`; unmatched ids are silently omitted; automatically tenant-scoped like `GET /users`

## Test plan
- [x] `npm run build`
- [x] `npm test` (33/33 passing — 3 new tests: adapter-level `findManyByIds`, service fallback to N `findById` when absent, tenant scoping)
- [x] `npm run ci` (full checklist incl. `npm pack --dry-run`)