### PR TITLE
feat: pluggable rate limiter for login/register

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,24 @@ Content-Type: application/json
 
 Unmatched ids are silently omitted rather than causing an error. Requires an `ADMIN` token and, like `GET /users`, is automatically scoped to the admin's `tenantId` when present. Accepts up to 100 ids per call. `UserRepo.findManyByIds` is optional on custom adapters — when absent, the service falls back to N `findById` calls, so existing adapters keep working unchanged.
 
+## Rate Limiting
+
+A pluggable `RateLimiter` port protects `POST /auth/login` and `POST /auth/register` from brute-force/abuse when provided:
+
+```ts
+import { createLibrary, createServer } from "my-crud-lib";
+import { makeMemoryRateLimiter } from "my-crud-lib/adapters/memory";
+
+const app = createServer();
+const lib = createLibrary(
+  { routesPrefix: "/api" },
+  { userRepo, rateLimiter: makeMemoryRateLimiter({ points: 5, durationMs: 60_000 }) } // 5 requests/min per IP+route
+);
+app.use(lib.router);
+```
+
+Exceeding the limit responds `429` with a `Retry-After` header. `makeMemoryRateLimiter` is fixed-window and per-process only (fine for a single instance or as a default); implement the `RateLimiter` port (`consume(key, cost?)`) against Redis or another shared store to enforce one limit across multiple instances. The `rateLimit(limiter, options?)` middleware is also exported standalone for your own routes.
+
 ## Build Checks
 
 ```bash

--- a/src/adapter-memory.ts
+++ b/src/adapter-memory.ts
@@ -1,1 +1,6 @@
-export { makeMemoryApiKeyRepo, makeMemoryIdempotencyStore, makeMemoryUserRepo } from './adapters/memory.js';
+export {
+  makeMemoryApiKeyRepo,
+  makeMemoryIdempotencyStore,
+  makeMemoryRateLimiter,
+  makeMemoryUserRepo,
+} from './adapters/memory.js';

--- a/src/adapters/memory.ts
+++ b/src/adapters/memory.ts
@@ -1,6 +1,7 @@
 import type { UserRepo } from '../core/ports/user.repo.js';
 import type { ApiKeyRecord, ApiKeyRepo } from '../core/ports/apiKey.repo.js';
 import type { IdempotencyRecord, IdempotencyStore } from '../core/ports/idempotency.repo.js';
+import type { RateLimiter } from '../core/ports/rateLimiter.repo.js';
 import type { AdminUpdateUserInput, Role, UserListItem } from '../modules/user/user.types.js';
 
 type StoredUser = UserListItem & { passwordHash: string };
@@ -188,6 +189,35 @@ export function makeMemoryIdempotencyStore(): IdempotencyStore {
         ...record,
         expiresAt: ttlMs !== undefined ? Date.now() + ttlMs : null,
       });
+    },
+  };
+}
+
+/**
+ * In-memory fixed-window `RateLimiter`: allows up to `points` calls per `key`
+ * within each `durationMs` window. Per-process only — use a shared store
+ * (Redis, a database) to enforce one limit across multiple instances.
+ */
+export function makeMemoryRateLimiter(options: { points: number; durationMs: number }): RateLimiter {
+  const windows = new Map<string, { count: number; resetAt: number }>();
+
+  return {
+    async consume(key, cost = 1) {
+      const now = Date.now();
+      const window = windows.get(key);
+
+      if (!window || window.resetAt <= now) {
+        const resetAt = now + options.durationMs;
+        windows.set(key, { count: cost, resetAt });
+        return { allowed: cost <= options.points, remaining: Math.max(options.points - cost, 0) };
+      }
+
+      if (window.count + cost > options.points) {
+        return { allowed: false, remaining: Math.max(options.points - window.count, 0), retryAfterMs: window.resetAt - now };
+      }
+
+      window.count += cost;
+      return { allowed: true, remaining: options.points - window.count };
     },
   };
 }

--- a/src/core/ports/rateLimiter.repo.ts
+++ b/src/core/ports/rateLimiter.repo.ts
@@ -1,0 +1,15 @@
+export type RateLimitResult = {
+  allowed: boolean;
+  remaining?: number;
+  retryAfterMs?: number;
+};
+
+/**
+ * Rate limiting port. `consume` should be atomic per `key` — implementations
+ * backed by a shared store (Redis, a database) let multiple instances of a
+ * service enforce one limit together.
+ */
+export interface RateLimiter {
+  /** Attempts to spend `cost` (default 1) points for `key`. Returns whether the request is allowed. */
+  consume(key: string, cost?: number): Promise<RateLimitResult>;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,8 @@ export type { ApiKeyRecord, ApiKeyRepo } from './core/ports/apiKey.repo.js';
 export { issueApiKey, verifyApiKey } from './utils/apiKey.js';
 export { idempotent } from './middleware/idempotent.js';
 export type { IdempotencyRecord, IdempotencyStore } from './core/ports/idempotency.repo.js';
+export { rateLimit } from './middleware/rateLimit.js';
+export type { RateLimiter, RateLimitResult } from './core/ports/rateLimiter.repo.js';
 export {
   AppError,
   EmailAlreadyExistsError,
@@ -85,11 +87,17 @@ export {
   makePrismaRefreshTokenRepo,
   makePrismaUserRepo,
 } from './adapters/prisma.js';
-export { makeMemoryApiKeyRepo, makeMemoryIdempotencyStore, makeMemoryUserRepo } from './adapters/memory.js';
+export {
+  makeMemoryApiKeyRepo,
+  makeMemoryIdempotencyStore,
+  makeMemoryRateLimiter,
+  makeMemoryUserRepo,
+} from './adapters/memory.js';
 
 import type { UserRepo } from './core/ports/user.repo.js';
 import type { AuthServiceDeps } from './modules/auth/auth.types.js';
 import type { IdempotencyStore } from './core/ports/idempotency.repo.js';
+import type { RateLimiter } from './core/ports/rateLimiter.repo.js';
 import { createAuthRouter } from './modules/auth/auth.controller.js';
 import { createUserRouter } from './modules/user/user.controller.js';
 import { createJwksRouter } from './modules/jwks/jwks.controller.js';
@@ -108,6 +116,8 @@ export type LibraryDeps = {
   userRepo: UserRepo;
   /** Enables `Idempotency-Key` support on `POST /auth/register` and `POST /users`. */
   idempotencyStore?: IdempotencyStore;
+  /** Enables rate limiting on `POST /auth/login` and `POST /auth/register`. */
+  rateLimiter?: RateLimiter;
 };
 
 function normalizePrefix(prefix?: string): string {
@@ -140,7 +150,12 @@ export function createLibrary(config: LibraryConfig, deps: LibraryDeps) {
 
   router.use(
     `${prefix}/auth`,
-    createAuthRouter({ userRepo: deps.userRepo, idempotencyStore: deps.idempotencyStore, ...config.auth }),
+    createAuthRouter({
+      userRepo: deps.userRepo,
+      idempotencyStore: deps.idempotencyStore,
+      rateLimiter: deps.rateLimiter,
+      ...config.auth,
+    }),
   );
   router.use(`${prefix}/users`, createUserRouter({ userRepo: deps.userRepo, idempotencyStore: deps.idempotencyStore }));
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,3 +3,4 @@ export { isAuth, type AuthRequest } from './middleware/isAuth.js';
 export { requireTenant, isSameTenant } from './middleware/tenant.js';
 export { isApiKey, type ApiKeyRequest } from './middleware/isApiKey.js';
 export { idempotent } from './middleware/idempotent.js';
+export { rateLimit } from './middleware/rateLimit.js';

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -1,0 +1,22 @@
+import type { Request, Response, NextFunction } from 'express';
+import type { RateLimiter } from '../core/ports/rateLimiter.repo.js';
+
+function defaultKey(req: Request): string {
+  return req.ip ?? 'unknown';
+}
+
+/** Enforces a `RateLimiter` on a route, keyed by `keyFn` (defaults to `req.ip`). Responds `429` with `Retry-After` when exceeded. */
+export function rateLimit(limiter: RateLimiter, options?: { keyFn?: (req: Request) => string; cost?: number }) {
+  const keyFn = options?.keyFn ?? defaultKey;
+
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const result = await limiter.consume(keyFn(req), options?.cost);
+    if (!result.allowed) {
+      if (result.retryAfterMs !== undefined) {
+        res.setHeader('Retry-After', Math.ceil(result.retryAfterMs / 1000).toString());
+      }
+      return res.status(429).json({ error: { code: 'RATE_LIMITED', message: 'Too many requests' } });
+    }
+    return next();
+  };
+}

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,8 +1,10 @@
 import { Router, type Request, type Response } from 'express';
 import { isAuth, type AuthRequest } from '../../middleware/isAuth.js';
 import { idempotent } from '../../middleware/idempotent.js';
+import { rateLimit } from '../../middleware/rateLimit.js';
 import { sendAppError } from '../../utils/errorHandler.js';
 import type { IdempotencyStore } from '../../core/ports/idempotency.repo.js';
+import type { RateLimiter } from '../../core/ports/rateLimiter.repo.js';
 import {
   emailVerificationConfirmSchema,
   emailVerificationRequestSchema,
@@ -17,6 +19,8 @@ import type { AuthServiceDeps } from './auth.types.js';
 export type AuthRouterDeps = AuthServiceDeps & {
   /** Enables `Idempotency-Key` support on `POST /register` when provided. */
   idempotencyStore?: IdempotencyStore;
+  /** Enables rate limiting on `POST /login` and `POST /register` when provided, keyed by IP + route. */
+  rateLimiter?: RateLimiter;
 };
 
 /**
@@ -28,7 +32,14 @@ export type AuthRouterDeps = AuthServiceDeps & {
 export function createAuthRouter(deps: AuthRouterDeps) {
   const router = Router();
   const service = makeAuthService(deps);
-  const registerMiddleware = deps.idempotencyStore ? [idempotent(deps.idempotencyStore)] : [];
+
+  const registerMiddleware = [
+    ...(deps.rateLimiter ? [rateLimit(deps.rateLimiter, { keyFn: (req) => `register:${req.ip}` })] : []),
+    ...(deps.idempotencyStore ? [idempotent(deps.idempotencyStore)] : []),
+  ];
+  const loginMiddleware = deps.rateLimiter
+    ? [rateLimit(deps.rateLimiter, { keyFn: (req) => `login:${req.ip}` })]
+    : [];
 
   router.post('/register', ...registerMiddleware, async (req: Request, res: Response) => {
     try {
@@ -40,7 +51,7 @@ export function createAuthRouter(deps: AuthRouterDeps) {
     }
   });
 
-  router.post('/login', async (req: Request, res: Response) => {
+  router.post('/login', ...loginMiddleware, async (req: Request, res: Response) => {
     try {
       const data = loginSchema.parse(req.body);
       const result = await service.loginUser(data);

--- a/tests/rate-limit.test.mjs
+++ b/tests/rate-limit.test.mjs
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+function makeRes() {
+  const res = {};
+  res.statusCode = 200;
+  res.headers = {};
+  res.status = (code) => { res.statusCode = code; return res; };
+  res.setHeader = (name, value) => { res.headers[name] = value; };
+  res.json = (body) => { res.body = body; return res; };
+  return res;
+}
+
+test('makeMemoryRateLimiter allows up to `points` requests then blocks within the window', async () => {
+  const { makeMemoryRateLimiter } = await import('../dist/adapters/memory.js');
+
+  const limiter = makeMemoryRateLimiter({ points: 3, durationMs: 60_000 });
+
+  const first = await limiter.consume('client-a');
+  const second = await limiter.consume('client-a');
+  const third = await limiter.consume('client-a');
+  const fourth = await limiter.consume('client-a');
+
+  assert.equal(first.allowed, true);
+  assert.equal(second.allowed, true);
+  assert.equal(third.allowed, true);
+  assert.equal(fourth.allowed, false);
+  assert.ok(fourth.retryAfterMs > 0);
+});
+
+test('makeMemoryRateLimiter tracks separate keys independently', async () => {
+  const { makeMemoryRateLimiter } = await import('../dist/adapters/memory.js');
+
+  const limiter = makeMemoryRateLimiter({ points: 1, durationMs: 60_000 });
+
+  const a1 = await limiter.consume('client-a');
+  const b1 = await limiter.consume('client-b');
+  const a2 = await limiter.consume('client-a');
+
+  assert.equal(a1.allowed, true);
+  assert.equal(b1.allowed, true);
+  assert.equal(a2.allowed, false);
+});
+
+test('rateLimit middleware blocks with 429 and Retry-After once the limiter denies', async () => {
+  const { makeMemoryRateLimiter } = await import('../dist/adapters/memory.js');
+  const { rateLimit } = await import('../dist/middleware/rateLimit.js');
+
+  const limiter = makeMemoryRateLimiter({ points: 1, durationMs: 60_000 });
+  const middleware = rateLimit(limiter, { keyFn: () => 'fixed-key' });
+
+  const req = { ip: '127.0.0.1' };
+
+  const res1 = makeRes();
+  let nextCalls = 0;
+  await middleware(req, res1, () => { nextCalls += 1; });
+  assert.equal(nextCalls, 1);
+
+  const res2 = makeRes();
+  await middleware(req, res2, () => { nextCalls += 1; });
+  assert.equal(nextCalls, 1, 'next must not be called once the limit is exceeded');
+  assert.equal(res2.statusCode, 429);
+  assert.ok(res2.headers['Retry-After']);
+});


### PR DESCRIPTION
Closes #37.

## Summary
- `RateLimiter` port: `consume(key, cost?)` → `{ allowed, remaining?, retryAfterMs? }`
- `rateLimit(limiter, options?)` middleware — 429 + `Retry-After` header when denied, otherwise pass-through
- `makeMemoryRateLimiter({ points, durationMs })` — fixed-window, per-process adapter
- `createAuthRouter`/`createLibrary` accept an optional `rateLimiter` dep, applied to `POST /auth/login` and `POST /auth/register`, keyed by `${route}:${req.ip}`
- Exported from `my-crud-lib`, `my-crud-lib/middleware`, `my-crud-lib/adapter-memory`

The port is intentionally minimal (`consume` only) so a Redis- or database-backed limiter for multi-instance deployments is a small adapter away — not shipped here to avoid adding a new dependency.

## Test plan
- [x] `npm run build`
- [x] `npm test` (36/36 passing — 3 new tests: window enforcement, independent keys, middleware 429 behavior)
- [x] `npm run ci` (full checklist incl. `npm pack --dry-run`)