### PR TITLE
feat: correlation id / request tracing middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,23 @@ app.use(lib.router);
 
 Exceeding the limit responds `429` with a `Retry-After` header. `makeMemoryRateLimiter` is fixed-window and per-process only (fine for a single instance or as a default); implement the `RateLimiter` port (`consume(key, cost?)`) against Redis or another shared store to enforce one limit across multiple instances. The `rateLimit(limiter, options?)` middleware is also exported standalone for your own routes.
 
+## Correlation ID / Request Tracing
+
+`createServer()` mounts `requestId()` by default: every response carries an `X-Request-Id` header, reusing the incoming header if the caller (a gateway, another service) already sent one, or generating a UUID otherwise. Read it via `req.id` in your own routes to correlate logs, or propagate it on outbound calls to other services:
+
+```ts
+import { requestId, type RequestWithId } from "my-crud-lib/middleware";
+
+app.use(requestId({ headerName: "X-Correlation-Id" })); // custom header name, if not using createServer()
+
+app.get("/whoami", (req, res) => {
+  console.log("request", (req as RequestWithId).id);
+  res.json({ ok: true });
+});
+```
+
+To correlate a request with library-triggered side effects (e.g. [lifecycle hooks](#lifecycle-hooks)), capture `req.id` in your own route before calling into the library, and include it when logging or calling `onUserCreated`/`sendPasswordReset`/etc. from your app code.
+
 ## Build Checks
 
 ```bash

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import express, { Router, type Express } from 'express';
 import cors from 'cors';
 import bodyParser from 'body-parser';
+import { requestId } from './middleware/requestId.js';
 export type { UserRepo } from './core/ports/user.repo.js';
 export type {
   AdminCreateUserInput,
@@ -63,6 +64,7 @@ export { idempotent } from './middleware/idempotent.js';
 export type { IdempotencyRecord, IdempotencyStore } from './core/ports/idempotency.repo.js';
 export { rateLimit } from './middleware/rateLimit.js';
 export type { RateLimiter, RateLimitResult } from './core/ports/rateLimiter.repo.js';
+export { requestId, type RequestWithId } from './middleware/requestId.js';
 export {
   AppError,
   EmailAlreadyExistsError,
@@ -132,6 +134,7 @@ function normalizePrefix(prefix?: string): string {
 export function createServer(): Express {
   const app = express();
   app.use(cors());
+  app.use(requestId());
   app.use(bodyParser.json());
   return app;
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,3 +4,4 @@ export { requireTenant, isSameTenant } from './middleware/tenant.js';
 export { isApiKey, type ApiKeyRequest } from './middleware/isApiKey.js';
 export { idempotent } from './middleware/idempotent.js';
 export { rateLimit } from './middleware/rateLimit.js';
+export { requestId, type RequestWithId } from './middleware/requestId.js';

--- a/src/middleware/requestId.ts
+++ b/src/middleware/requestId.ts
@@ -1,0 +1,22 @@
+import { randomUUID } from 'node:crypto';
+import type { Request, Response, NextFunction } from 'express';
+
+export type RequestWithId = Request & { id: string };
+
+/**
+ * Reads a correlation id from the request (default `X-Request-Id`), or
+ * generates one, attaches it as `req.id`, and reflects it back in the
+ * response header — so a request can be traced across services that all
+ * mount this middleware (gateway -> this service -> downstream calls).
+ */
+export function requestId(options?: { headerName?: string }) {
+  const headerName = (options?.headerName ?? 'x-request-id').toLowerCase();
+
+  return (req: Request, res: Response, next: NextFunction) => {
+    const incoming = req.headers[headerName];
+    const id = (Array.isArray(incoming) ? incoming[0] : incoming) || randomUUID();
+    (req as RequestWithId).id = id;
+    res.setHeader('X-Request-Id', id);
+    next();
+  };
+}

--- a/tests/request-id.test.mjs
+++ b/tests/request-id.test.mjs
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+function makeRes() {
+  const res = {};
+  res.headers = {};
+  res.setHeader = (name, value) => { res.headers[name] = value; };
+  return res;
+}
+
+test('requestId generates an id and reflects it in the response header when none is sent', async () => {
+  const { requestId } = await import('../dist/middleware/requestId.js');
+
+  const req = { headers: {} };
+  const res = makeRes();
+  let nextCalled = false;
+
+  requestId()(req, res, () => { nextCalled = true; });
+
+  assert.equal(nextCalled, true);
+  assert.equal(typeof req.id, 'string');
+  assert.ok(req.id.length > 0);
+  assert.equal(res.headers['X-Request-Id'], req.id);
+});
+
+test('requestId reuses an incoming X-Request-Id header instead of generating a new one', async () => {
+  const { requestId } = await import('../dist/middleware/requestId.js');
+
+  const req = { headers: { 'x-request-id': 'incoming-id-123' } };
+  const res = makeRes();
+
+  requestId()(req, res, () => {});
+
+  assert.equal(req.id, 'incoming-id-123');
+  assert.equal(res.headers['X-Request-Id'], 'incoming-id-123');
+});
+
+test('requestId supports a custom header name', async () => {
+  const { requestId } = await import('../dist/middleware/requestId.js');
+
+  const req = { headers: { 'x-correlation-id': 'corr-1' } };
+  const res = makeRes();
+
+  requestId({ headerName: 'X-Correlation-Id' })(req, res, () => {});
+
+  assert.equal(req.id, 'corr-1');
+});


### PR DESCRIPTION
Closes #38.

## Summary
- `requestId(options?)` middleware: reads `X-Request-Id` (or a custom header name), generates a UUID if absent, attaches `req.id`, reflects it in the response header
- `createServer()` mounts it by default — every response from a `createServer()`-based app now carries `X-Request-Id`
- Exported standalone (`requestId`, `RequestWithId`) from `my-crud-lib` and `my-crud-lib/middleware` for apps that build their own Express app instead of using `createServer()`
- README documents propagating `req.id` into lifecycle-hook side effects for correlated logging

## Test plan
- [x] `npm run build`
- [x] `npm test` (39/39 passing — 3 new tests: id generation, reuse of incoming header, custom header name)
- [x] `npm run ci` (full checklist incl. `npm pack --dry-run`)