### PR TITLE
feat: health check endpoints (GET /health, GET /ready)

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,21 @@ app.get("/whoami", (req, res) => {
 
 To correlate a request with library-triggered side effects (e.g. [lifecycle hooks](#lifecycle-hooks)), capture `req.id` in your own route before calling into the library, and include it when logging or calling `onUserCreated`/`sendPasswordReset`/etc. from your app code.
 
+## Health Checks
+
+`createLibrary`/`mountDefaultRoutes` mount `GET /health` and `GET /ready` (unprefixed, by convention) by default — useful for orchestrator probes (Kubernetes, ECS, etc.):
+
+- `GET /health` — liveness, always `200 { "status": "ok" }`, no dependencies checked.
+- `GET /ready` — readiness, calls `userRepo.count({})`; `200 { "status": "ok" }` if it resolves, `503 { "status": "error", "error": "..." }` if it throws (e.g. the database is unreachable).
+
+Disable them with `health: false` if your app already defines these routes:
+
+```ts
+createLibrary({ health: false }, { userRepo });
+```
+
+`createHealthRouter({ userRepo })` is also exported standalone.
+
 ## Build Checks
 
 ```bash

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export type {
 export { createUserRouter } from './modules/user/user.controller.js';
 export { createAuthRouter } from './modules/auth/auth.controller.js';
 export { createJwksRouter } from './modules/jwks/jwks.controller.js';
+export { createHealthRouter } from './modules/health/health.controller.js';
 export { getJwks, type Jwk } from './utils/jwks.js';
 export { DEFAULT_REGISTER_ROLE, resolveRegisterRole } from './modules/auth/auth.defaults.js';
 export { makeAuthService } from './modules/auth/auth.service.js';
@@ -103,6 +104,7 @@ import type { RateLimiter } from './core/ports/rateLimiter.repo.js';
 import { createAuthRouter } from './modules/auth/auth.controller.js';
 import { createUserRouter } from './modules/user/user.controller.js';
 import { createJwksRouter } from './modules/jwks/jwks.controller.js';
+import { createHealthRouter } from './modules/health/health.controller.js';
 import { getJwtAlgorithm } from './config/env.js';
 
 /** Options for `createLibrary`/`mountDefaultRoutes`. */
@@ -111,6 +113,8 @@ export type LibraryConfig = {
   routesPrefix?: string;
   /** Passed through to `createAuthRouter` alongside `deps.userRepo`. */
   auth?: Omit<AuthServiceDeps, 'userRepo'>;
+  /** Mounts `GET /health` and `GET /ready` (unprefixed). Defaults to `true`. */
+  health?: boolean;
 };
 
 /** Dependencies for `createLibrary`/`mountDefaultRoutes`. */
@@ -165,6 +169,11 @@ export function createLibrary(config: LibraryConfig, deps: LibraryDeps) {
   // JWKS is a well-known, unprefixed path by convention, and only meaningful with RS256.
   if (getJwtAlgorithm() === 'RS256') {
     router.use(createJwksRouter());
+  }
+
+  // /health and /ready are unprefixed by convention, for orchestrator probes.
+  if (config.health !== false) {
+    router.use(createHealthRouter({ userRepo: deps.userRepo }));
   }
 
   return { router };

--- a/src/modules/health/health.controller.ts
+++ b/src/modules/health/health.controller.ts
@@ -1,0 +1,29 @@
+import { Router } from 'express';
+import type { UserRepo } from '../../core/ports/user.repo.js';
+
+/**
+ * Exposes `GET /health` (liveness — always 200, no dependencies) and
+ * `GET /ready` (readiness — 200 only if `userRepo` responds, 503 otherwise).
+ * Intended for orchestrator probes (Kubernetes, ECS, etc.).
+ */
+export function createHealthRouter(deps: { userRepo: UserRepo }) {
+  const router = Router();
+
+  router.get('/health', (_req, res) => {
+    res.status(200).json({ status: 'ok' });
+  });
+
+  router.get('/ready', async (_req, res) => {
+    try {
+      await deps.userRepo.count({});
+      res.status(200).json({ status: 'ok' });
+    } catch (err) {
+      res.status(503).json({
+        status: 'error',
+        error: err instanceof Error ? err.message : 'Readiness check failed',
+      });
+    }
+  });
+
+  return router;
+}

--- a/tests/health.test.mjs
+++ b/tests/health.test.mjs
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import http from 'node:http';
+
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-secret-for-health-test';
+
+async function requestJson(server, path) {
+  const { port } = server.address();
+  return new Promise((resolve, reject) => {
+    http.get(`http://127.0.0.1:${port}${path}`, (res) => {
+      let data = '';
+      res.on('data', (chunk) => { data += chunk; });
+      res.on('end', () => resolve({ status: res.statusCode, body: JSON.parse(data) }));
+    }).on('error', reject);
+  });
+}
+
+async function requestStatus(server, path) {
+  const { port } = server.address();
+  return new Promise((resolve, reject) => {
+    http.get(`http://127.0.0.1:${port}${path}`, (res) => {
+      res.resume();
+      res.on('end', () => resolve(res.statusCode));
+    }).on('error', reject);
+  });
+}
+
+test('GET /health always returns 200 and GET /ready reflects userRepo health', async () => {
+  const { createLibrary, createServer } = await import('../dist/index.js');
+  const { makeMemoryUserRepo } = await import('../dist/adapters/memory.js');
+
+  const app = createServer();
+  const lib = createLibrary({}, { userRepo: makeMemoryUserRepo() });
+  app.use(lib.router);
+
+  const server = app.listen(0);
+  try {
+    await new Promise((resolve) => server.once('listening', resolve));
+
+    const health = await requestJson(server, '/health');
+    assert.equal(health.status, 200);
+    assert.equal(health.body.status, 'ok');
+
+    const ready = await requestJson(server, '/ready');
+    assert.equal(ready.status, 200);
+    assert.equal(ready.body.status, 'ok');
+  } finally {
+    server.close();
+  }
+});
+
+test('GET /ready returns 503 when userRepo.count throws', async () => {
+  const { createLibrary, createServer } = await import('../dist/index.js');
+
+  const brokenUserRepo = {
+    async count() { throw new Error('DB_DOWN'); },
+    async findMany() { return []; },
+    async findById() { return null; },
+    async findByEmail() { return null; },
+    async create(input) { return { id: 1, ...input }; },
+    async update(_id, input) { return { id: 1, ...input }; },
+    async delete() {},
+    async updateMe(_id, input) { return { id: 1, ...input }; },
+  };
+
+  const app = createServer();
+  const lib = createLibrary({}, { userRepo: brokenUserRepo });
+  app.use(lib.router);
+
+  const server = app.listen(0);
+  try {
+    await new Promise((resolve) => server.once('listening', resolve));
+    const ready = await requestJson(server, '/ready');
+    assert.equal(ready.status, 503);
+    assert.equal(ready.body.status, 'error');
+  } finally {
+    server.close();
+  }
+});
+
+test('config.health = false disables the health routes', async () => {
+  const { createLibrary, createServer } = await import('../dist/index.js');
+  const { makeMemoryUserRepo } = await import('../dist/adapters/memory.js');
+
+  const app = createServer();
+  const lib = createLibrary({ health: false }, { userRepo: makeMemoryUserRepo() });
+  app.use(lib.router);
+
+  const server = app.listen(0);
+  try {
+    await new Promise((resolve) => server.once('listening', resolve));
+    const status = await requestStatus(server, '/health');
+    assert.equal(status, 404);
+  } finally {
+    server.close();
+  }
+});


### PR DESCRIPTION
Closes #39.

## Summary
- `createHealthRouter({ userRepo })`: `GET /health` (liveness, always 200) and `GET /ready` (readiness, 200 if `userRepo.count({})` resolves, 503 with the error message otherwise)
- Mounted automatically (unprefixed) by `createLibrary`/`mountDefaultRoutes`; disable via `config.health = false`
- Exported standalone as `createHealthRouter`

## Test plan
- [x] `npm run build`
- [x] `npm test` (42/42 passing — 3 new tests spin up a real HTTP server: healthy path, `/ready` 503 on a repo that throws, and `health: false` disabling the routes)
- [x] `npm run ci` (full checklist incl. `npm pack --dry-run`)