### PR TITLE
fix: address code review findings (error handling, tenant registration, idempotency cleanup, version bump)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,27 @@ All notable changes to `my-crud-lib` are documented here.
 
 This project follows semantic versioning. Breaking changes are called out explicitly and should be reviewed before upgrading.
 
-## 3.0.0 - Unreleased
+## 3.1.0 - Unreleased
+
+### Added
+
+- Added optional multi-tenancy: `tenantId` on `UserRepo`, `UserListItem`, and JWT payloads; `req.user.tenantId` via `isAuth`; admin `GET /users` and `GET/PUT/DELETE /users/:id` are automatically tenant-scoped; new `requireTenant()`/`isSameTenant()` middleware.
+- Added machine-to-machine API key authentication: `ApiKeyRepo` port, `issueApiKey`/`verifyApiKey` helpers, `isApiKey` middleware, and `makeMemoryApiKeyRepo`/`makePrismaApiKeyRepo` adapters.
+- Added optional RS256/JWKS support (`JWT_ALG=RS256`, `JWT_PRIVATE_KEY`/`JWT_PUBLIC_KEY`/`JWT_KEY_ID`) with an auto-mounted `GET /.well-known/jwks.json`, so other services can verify tokens without a shared secret.
+- Added idempotency key support (`IdempotencyStore` port, `idempotent` middleware) on `POST /auth/register` and admin `POST /users`, with memory and Prisma adapters.
+- Added bulk user lookup: optional `UserRepo.findManyByIds`, and `POST /users/batch`.
+- Added a pluggable rate limiter (`RateLimiter` port, `rateLimit` middleware, `makeMemoryRateLimiter`) applied to `POST /auth/login` and `POST /auth/register` when configured.
+- Added a correlation id / request tracing middleware (`requestId`), mounted by default in `createServer()`.
+- Added health check endpoints (`GET /health`, `GET /ready`), mounted by default in `createLibrary`/`mountDefaultRoutes`.
+- Added a Jest + Supertest end-to-end API test suite (`tests/api/`), run in CI on every pull request alongside the existing `node:test` suite.
+
+### Security
+
+- `POST /auth/register` now ignores any client-supplied `tenantId` by default, since self-registration is unauthenticated and accepting one would let anyone join any tenant by guessing or copying its id. Opt in with `allowTenantIdOnRegister: true` only if your app has its own way to authorize tenant membership. Server-side calls to `makeAuthService(...).registerUser()` are unaffected and can still set `tenantId` directly.
+- `idempotent`, `rateLimit`, and `isApiKey` middleware now catch errors from their underlying store/repo and respond with a normal error instead of leaving the request hanging if the backing store (e.g. a Prisma- or Redis-backed adapter) throws.
+- `makePrismaIdempotencyStore` now evicts an expired record the next time it's read with the same key (previously it never deleted expired rows).
+
+## 3.0.0 - 2026-07-24
 
 ### Breaking Changes
 

--- a/README.md
+++ b/README.md
@@ -373,7 +373,8 @@ app.get("/internal/reports", isAuth, requireTenant(), handler);
 ```
 
 Behavior:
-- `POST /auth/register` and `POST /users` accept an optional `tenantId`.
+- `POST /users` (admin-only) accepts an optional `tenantId`. `makeAuthService(...).registerUser()` also accepts one directly, for trusted server-side calls (e.g. your own invite-acceptance endpoint that already verified which tenant to join).
+- `POST /auth/register` is anonymous, so it **ignores** any `tenantId` in the request body by default — accepting one from an unauthenticated caller would let anyone join any tenant by guessing or copying its id. Opt in explicitly with `allowTenantIdOnRegister: true` only if your app has its own way to authorize which tenant a new registrant may join.
 - Access/refresh tokens carry `tenantId` when the user has one; `isAuth` exposes it as `req.user.tenantId`.
 - Admin `GET /users` is automatically scoped to `req.user.tenantId` when the admin's token carries one — an admin token scoped to a tenant can never list another tenant's users.
 - `GET/PUT/DELETE /users/:id` respond `404` (not `403`, to avoid leaking existence) when the target user belongs to a different tenant.
@@ -381,6 +382,8 @@ Behavior:
 - `isSameTenant(getResourceTenantId?)` middleware compares `req.user.tenantId` against a resolved resource tenant id (defaults to `req.params.tenantId`), for your own routes.
 
 Single-tenant apps are unaffected: omit `tenantId` everywhere and behavior is identical to before.
+
+**Security note:** any route that trusts `req.user.tenantId` to authorize access to tenant-scoped resources is only as safe as how tenant membership is granted. Prefer assigning `tenantId` from a trusted, server-side source (an invite token, an admin action) over letting it flow from unauthenticated user input.
 
 ## API Keys (Machine-to-Machine Auth)
 
@@ -434,6 +437,8 @@ app.use(lib.router);
 ```
 
 Send `Idempotency-Key: <uuid>` on the request. The first call runs normally and its response is stored; any repeat with the same key returns the exact same response (marked with an `Idempotent-Replay: true` header) without re-executing the handler. Requests without the header are unaffected — idempotency is opt-in per call. The `idempotent(store, options?)` middleware is also exported standalone for use on your own routes.
+
+`makePrismaIdempotencyStore` evicts an expired record the next time it's read with the same key, but keys that are set once and never re-read are not cleaned up automatically — schedule a periodic `DELETE FROM "IdempotencyKey" WHERE "expiresAt" < now()` (or equivalent) if you expect high key churn.
 
 ## Bulk User Lookup
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "my-crud-lib",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "my-crud-lib",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "bcryptjs": "^2.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-crud-lib",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "TypeScript auth and user/profile CRUD helpers for Express with Prisma and custom repository adapters",
   "license": "MIT",
   "author": "Riccardo Sensi",

--- a/src/adapters/prisma.ts
+++ b/src/adapters/prisma.ts
@@ -353,7 +353,13 @@ export function makePrismaIdempotencyStore(prisma: PrismaClient): IdempotencySto
     async get(key) {
       const record = await (prisma as any).idempotencyKey.findUnique({ where: { key } });
       if (!record) return null;
-      if (record.expiresAt && record.expiresAt.getTime() <= Date.now()) return null;
+      if (record.expiresAt && record.expiresAt.getTime() <= Date.now()) {
+        // Lazily evict on read, same as the in-memory adapter. This alone doesn't
+        // bound table growth for keys that are set once and never re-read with
+        // the same key — schedule a periodic DELETE WHERE expiresAt < now() too.
+        await (prisma as any).idempotencyKey.delete({ where: { key } }).catch(() => {});
+        return null;
+      }
       return { status: record.status, body: record.body };
     },
 

--- a/src/middleware/idempotent.ts
+++ b/src/middleware/idempotent.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, NextFunction } from 'express';
 import type { IdempotencyStore } from '../core/ports/idempotency.repo.js';
+import { sendAppError } from '../utils/errorHandler.js';
 
 /**
  * Replays a stored response for repeated requests carrying the same
@@ -16,7 +17,13 @@ export function idempotent(store: IdempotencyStore, options?: { headerName?: str
     const key = Array.isArray(raw) ? raw[0] : raw;
     if (!key) return next();
 
-    const existing = await store.get(key);
+    let existing;
+    try {
+      existing = await store.get(key);
+    } catch (err) {
+      return sendAppError(res, err);
+    }
+
     if (existing) {
       res.setHeader('Idempotent-Replay', 'true');
       return res.status(existing.status).json(existing.body);

--- a/src/middleware/isApiKey.ts
+++ b/src/middleware/isApiKey.ts
@@ -1,6 +1,7 @@
 import type { Request, Response, NextFunction } from 'express';
 import type { ApiKeyRepo } from '../core/ports/apiKey.repo.js';
 import { verifyApiKey } from '../utils/apiKey.js';
+import { sendAppError } from '../utils/errorHandler.js';
 
 export type ApiKeyRequest = Request & {
   apiKey?: { id: string; name?: string | null; scopes: string[]; tenantId?: string | number };
@@ -29,7 +30,13 @@ export function isApiKey(apiKeyRepo: ApiKeyRepo, options?: { requiredScopes?: st
     }
 
     const [id] = key.split('.');
-    const record = id ? await apiKeyRepo.findById(id) : null;
+    let record;
+    try {
+      record = id ? await apiKeyRepo.findById(id) : null;
+    } catch (err) {
+      return sendAppError(res, err);
+    }
+
     if (!record || record.revokedAt || !verifyApiKey(key, record)) {
       return res.status(401).json({ error: { code: 'UNAUTHORIZED', message: 'Invalid or revoked API key' } });
     }

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, NextFunction } from 'express';
 import type { RateLimiter } from '../core/ports/rateLimiter.repo.js';
+import { sendAppError } from '../utils/errorHandler.js';
 
 function defaultKey(req: Request): string {
   return req.ip ?? 'unknown';
@@ -10,7 +11,13 @@ export function rateLimit(limiter: RateLimiter, options?: { keyFn?: (req: Reques
   const keyFn = options?.keyFn ?? defaultKey;
 
   return async (req: Request, res: Response, next: NextFunction) => {
-    const result = await limiter.consume(keyFn(req), options?.cost);
+    let result;
+    try {
+      result = await limiter.consume(keyFn(req), options?.cost);
+    } catch (err) {
+      return sendAppError(res, err);
+    }
+
     if (!result.allowed) {
       if (result.retryAfterMs !== undefined) {
         res.setHeader('Retry-After', Math.ceil(result.retryAfterMs / 1000).toString());

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -44,7 +44,10 @@ export function createAuthRouter(deps: AuthRouterDeps) {
   router.post('/register', ...registerMiddleware, async (req: Request, res: Response) => {
     try {
       const data = registerSchema.parse(req.body);
-      const result = await service.registerUser(data);
+      // Self-registration is unauthenticated: only honor a client-supplied tenantId
+      // when the app has explicitly opted in, otherwise anyone could join any tenant.
+      const tenantId = deps.allowTenantIdOnRegister ? data.tenantId : undefined;
+      const result = await service.registerUser({ ...data, tenantId });
       return res.status(201).json(result);
     } catch (err) {
       return sendAppError(res, err);

--- a/src/modules/auth/auth.types.ts
+++ b/src/modules/auth/auth.types.ts
@@ -122,6 +122,15 @@ export type AuthServiceDeps = {
   onLoginSuccess?: (user: AuthUser) => Promise<void> | void;
   /** Called after a password reset is confirmed and the new password is saved. Errors are not thrown to the caller. */
   onPasswordReset?: (user: AuthUser) => Promise<void> | void;
+  /**
+   * Allows an anonymous caller of `POST /register` to set their own `tenantId`.
+   * Defaults to `false`: self-registration is unauthenticated, so accepting a
+   * client-supplied tenant id would let anyone join any tenant by guessing or
+   * copying its id. Leave this off and assign `tenantId` server-side instead
+   * (e.g. from a verified invite token) unless you have your own way to
+   * authorize which tenant a new registrant may join.
+   */
+  allowTenantIdOnRegister?: boolean;
 };
 
 export type AuthUser = UserListItem;

--- a/tests/api-key-auth.test.mjs
+++ b/tests/api-key-auth.test.mjs
@@ -66,3 +66,20 @@ test('isApiKey enforces requiredScopes', async () => {
   );
   assert.equal(res.statusCode, 403);
 });
+
+test('isApiKey responds 500 instead of hanging when the repo throws', async () => {
+  const { isApiKey } = await import('../dist/middleware/isApiKey.js');
+
+  const brokenRepo = {
+    async findById() { throw new Error('REPO_DOWN'); },
+    async create() {},
+    async revoke() {},
+  };
+  const middleware = isApiKey(brokenRepo);
+
+  const res = makeRes();
+  await middleware({ headers: { 'x-api-key': 'id.secret' } }, res, () => assert.fail('should not call next'));
+
+  assert.equal(res.statusCode, 500);
+  assert.equal(res.body.error.code, 'INTERNAL_ERROR');
+});

--- a/tests/api/auth.test.js
+++ b/tests/api/auth.test.js
@@ -34,6 +34,22 @@ describe('POST /api/auth/register', () => {
     const fields = res.body.error.details.map((d) => d.field);
     expect(fields).toEqual(expect.arrayContaining(['email', 'password']));
   });
+
+  it('ignores a client-supplied tenantId by default (anonymous self-registration cannot join a tenant)', async () => {
+    const { app } = buildApp();
+    const res = await registerUser(request, app, { tenantId: 'someone-elses-tenant' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.user.tenantId).toBeFalsy();
+  });
+
+  it('honors a client-supplied tenantId only when allowTenantIdOnRegister is enabled', async () => {
+    const { app } = buildApp({ auth: { allowTenantIdOnRegister: true } });
+    const res = await registerUser(request, app, { tenantId: 'tenant-a' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.user.tenantId).toBe('tenant-a');
+  });
 });
 
 describe('POST /api/auth/login', () => {

--- a/tests/idempotency.test.mjs
+++ b/tests/idempotency.test.mjs
@@ -72,3 +72,19 @@ test('memory idempotency store expires records after ttlMs', async () => {
   const afterExpiry = await store.get('short-lived');
   assert.equal(afterExpiry, null);
 });
+
+test('idempotent middleware responds 500 instead of hanging when the store throws', async () => {
+  const { idempotent } = await import('../dist/middleware/idempotent.js');
+
+  const brokenStore = {
+    async get() { throw new Error('STORE_DOWN'); },
+    async set() {},
+  };
+  const middleware = idempotent(brokenStore);
+
+  const res = makeRes();
+  await middleware({ headers: { 'idempotency-key': 'k1' } }, res, () => assert.fail('should not call next'));
+
+  assert.equal(res.statusCode, 500);
+  assert.equal(res.body.error.code, 'INTERNAL_ERROR');
+});

--- a/tests/rate-limit.test.mjs
+++ b/tests/rate-limit.test.mjs
@@ -62,3 +62,18 @@ test('rateLimit middleware blocks with 429 and Retry-After once the limiter deni
   assert.equal(res2.statusCode, 429);
   assert.ok(res2.headers['Retry-After']);
 });
+
+test('rateLimit middleware responds 500 instead of hanging when the limiter throws', async () => {
+  const { rateLimit } = await import('../dist/middleware/rateLimit.js');
+
+  const brokenLimiter = {
+    async consume() { throw new Error('LIMITER_DOWN'); },
+  };
+  const middleware = rateLimit(brokenLimiter);
+
+  const res = makeRes();
+  await middleware({ ip: '127.0.0.1' }, res, () => assert.fail('should not call next'));
+
+  assert.equal(res.statusCode, 500);
+  assert.equal(res.body.error.code, 'INTERNAL_ERROR');
+});


### PR DESCRIPTION
Fixes the 4 findings from the pre-master review of the #32-#40 batch.

## 1. Unhandled async rejections in idempotent/rateLimit/isApiKey middleware
All three now wrap their store/repo call in try/catch and respond via `sendAppError` on failure, instead of leaving the request hanging (Express 4 doesn't catch a rejected promise from an async middleware). New tests confirm a throwing store/limiter/repo now produces a `500` instead of no response.

## 2. Unauthenticated tenant assignment on self-registration
`POST /auth/register` now ignores any client-supplied `tenantId` by default. New `allowTenantIdOnRegister` flag on `AuthServiceDeps` (default `false`) opts back in for apps that have their own way to authorize tenant membership. `makeAuthService(...).registerUser()` called directly (server-side, e.g. an invite-acceptance endpoint) is unaffected. README's Multi-Tenancy section documents the rationale and the new flag.

## 3. Prisma idempotency store never cleaned up expired rows
`makePrismaIdempotencyStore.get()` now deletes an expired record on read, matching the memory adapter. README notes a periodic cleanup job is still recommended for keys that are set once and never re-read.

## 4. Version/changelog not updated for the #32-#40 batch
Bumped to `3.1.0` (all additive/opt-in; the tenantId change tightens an unsafe default rather than breaking a legitimate use case) and added a full `CHANGELOG.md` entry for the batch plus these fixes.

## Test plan
- [x] `npm run build`
- [x] `npm test` (45/45 passing, 3 new regression tests for the error-handling fix)
- [x] `npm run test:api` (32/32 passing, 2 new tests for the tenantId registration fix)
- [x] `npm run ci` (full checklist incl. `npm pack --dry-run`)