### PR TITLE
Release 3.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Run tests
         run: npm test
 
+      - name: Run API test suite (Jest)
+        run: npm run test:api
+
       - name: Verify public exports
         run: npm run smoke:exports
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,27 @@ All notable changes to `my-crud-lib` are documented here.
 
 This project follows semantic versioning. Breaking changes are called out explicitly and should be reviewed before upgrading.
 
-## 3.0.0 - Unreleased
+## 3.1.0 - Unreleased
+
+### Added
+
+- Added optional multi-tenancy: `tenantId` on `UserRepo`, `UserListItem`, and JWT payloads; `req.user.tenantId` via `isAuth`; admin `GET /users` and `GET/PUT/DELETE /users/:id` are automatically tenant-scoped; new `requireTenant()`/`isSameTenant()` middleware.
+- Added machine-to-machine API key authentication: `ApiKeyRepo` port, `issueApiKey`/`verifyApiKey` helpers, `isApiKey` middleware, and `makeMemoryApiKeyRepo`/`makePrismaApiKeyRepo` adapters.
+- Added optional RS256/JWKS support (`JWT_ALG=RS256`, `JWT_PRIVATE_KEY`/`JWT_PUBLIC_KEY`/`JWT_KEY_ID`) with an auto-mounted `GET /.well-known/jwks.json`, so other services can verify tokens without a shared secret.
+- Added idempotency key support (`IdempotencyStore` port, `idempotent` middleware) on `POST /auth/register` and admin `POST /users`, with memory and Prisma adapters.
+- Added bulk user lookup: optional `UserRepo.findManyByIds`, and `POST /users/batch`.
+- Added a pluggable rate limiter (`RateLimiter` port, `rateLimit` middleware, `makeMemoryRateLimiter`) applied to `POST /auth/login` and `POST /auth/register` when configured.
+- Added a correlation id / request tracing middleware (`requestId`), mounted by default in `createServer()`.
+- Added health check endpoints (`GET /health`, `GET /ready`), mounted by default in `createLibrary`/`mountDefaultRoutes`.
+- Added a Jest + Supertest end-to-end API test suite (`tests/api/`), run in CI on every pull request alongside the existing `node:test` suite.
+
+### Security
+
+- `POST /auth/register` now ignores any client-supplied `tenantId` by default, since self-registration is unauthenticated and accepting one would let anyone join any tenant by guessing or copying its id. Opt in with `allowTenantIdOnRegister: true` only if your app has its own way to authorize tenant membership. Server-side calls to `makeAuthService(...).registerUser()` are unaffected and can still set `tenantId` directly.
+- `idempotent`, `rateLimit`, and `isApiKey` middleware now catch errors from their underlying store/repo and respond with a normal error instead of leaving the request hanging if the backing store (e.g. a Prisma- or Redis-backed adapter) throws.
+- `makePrismaIdempotencyStore` now evicts an expired record the next time it's read with the same key (previously it never deleted expired rows).
+
+## 3.0.0 - 2026-07-24
 
 ### Breaking Changes
 

--- a/README.md
+++ b/README.md
@@ -373,7 +373,8 @@ app.get("/internal/reports", isAuth, requireTenant(), handler);
 ```
 
 Behavior:
-- `POST /auth/register` and `POST /users` accept an optional `tenantId`.
+- `POST /users` (admin-only) accepts an optional `tenantId`. `makeAuthService(...).registerUser()` also accepts one directly, for trusted server-side calls (e.g. your own invite-acceptance endpoint that already verified which tenant to join).
+- `POST /auth/register` is anonymous, so it **ignores** any `tenantId` in the request body by default — accepting one from an unauthenticated caller would let anyone join any tenant by guessing or copying its id. Opt in explicitly with `allowTenantIdOnRegister: true` only if your app has its own way to authorize which tenant a new registrant may join.
 - Access/refresh tokens carry `tenantId` when the user has one; `isAuth` exposes it as `req.user.tenantId`.
 - Admin `GET /users` is automatically scoped to `req.user.tenantId` when the admin's token carries one — an admin token scoped to a tenant can never list another tenant's users.
 - `GET/PUT/DELETE /users/:id` respond `404` (not `403`, to avoid leaking existence) when the target user belongs to a different tenant.
@@ -381,6 +382,8 @@ Behavior:
 - `isSameTenant(getResourceTenantId?)` middleware compares `req.user.tenantId` against a resolved resource tenant id (defaults to `req.params.tenantId`), for your own routes.
 
 Single-tenant apps are unaffected: omit `tenantId` everywhere and behavior is identical to before.
+
+**Security note:** any route that trusts `req.user.tenantId` to authorize access to tenant-scoped resources is only as safe as how tenant membership is granted. Prefer assigning `tenantId` from a trusted, server-side source (an invite token, an admin action) over letting it flow from unauthenticated user input.
 
 ## API Keys (Machine-to-Machine Auth)
 
@@ -434,6 +437,8 @@ app.use(lib.router);
 ```
 
 Send `Idempotency-Key: <uuid>` on the request. The first call runs normally and its response is stored; any repeat with the same key returns the exact same response (marked with an `Idempotent-Replay: true` header) without re-executing the handler. Requests without the header are unaffected — idempotency is opt-in per call. The `idempotent(store, options?)` middleware is also exported standalone for use on your own routes.
+
+`makePrismaIdempotencyStore` evicts an expired record the next time it's read with the same key, but keys that are set once and never re-read are not cleaned up automatically — schedule a periodic `DELETE FROM "IdempotencyKey" WHERE "expiresAt" < now()` (or equivalent) if you expect high key churn.
 
 ## Bulk User Lookup
 

--- a/README.md
+++ b/README.md
@@ -453,6 +453,24 @@ Content-Type: application/json
 
 Unmatched ids are silently omitted rather than causing an error. Requires an `ADMIN` token and, like `GET /users`, is automatically scoped to the admin's `tenantId` when present. Accepts up to 100 ids per call. `UserRepo.findManyByIds` is optional on custom adapters — when absent, the service falls back to N `findById` calls, so existing adapters keep working unchanged.
 
+## Rate Limiting
+
+A pluggable `RateLimiter` port protects `POST /auth/login` and `POST /auth/register` from brute-force/abuse when provided:
+
+```ts
+import { createLibrary, createServer } from "my-crud-lib";
+import { makeMemoryRateLimiter } from "my-crud-lib/adapters/memory";
+
+const app = createServer();
+const lib = createLibrary(
+  { routesPrefix: "/api" },
+  { userRepo, rateLimiter: makeMemoryRateLimiter({ points: 5, durationMs: 60_000 }) } // 5 requests/min per IP+route
+);
+app.use(lib.router);
+```
+
+Exceeding the limit responds `429` with a `Retry-After` header. `makeMemoryRateLimiter` is fixed-window and per-process only (fine for a single instance or as a default); implement the `RateLimiter` port (`consume(key, cost?)`) against Redis or another shared store to enforce one limit across multiple instances. The `rateLimit(limiter, options?)` middleware is also exported standalone for your own routes.
+
 ## Build Checks
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -471,6 +471,23 @@ app.use(lib.router);
 
 Exceeding the limit responds `429` with a `Retry-After` header. `makeMemoryRateLimiter` is fixed-window and per-process only (fine for a single instance or as a default); implement the `RateLimiter` port (`consume(key, cost?)`) against Redis or another shared store to enforce one limit across multiple instances. The `rateLimit(limiter, options?)` middleware is also exported standalone for your own routes.
 
+## Correlation ID / Request Tracing
+
+`createServer()` mounts `requestId()` by default: every response carries an `X-Request-Id` header, reusing the incoming header if the caller (a gateway, another service) already sent one, or generating a UUID otherwise. Read it via `req.id` in your own routes to correlate logs, or propagate it on outbound calls to other services:
+
+```ts
+import { requestId, type RequestWithId } from "my-crud-lib/middleware";
+
+app.use(requestId({ headerName: "X-Correlation-Id" })); // custom header name, if not using createServer()
+
+app.get("/whoami", (req, res) => {
+  console.log("request", (req as RequestWithId).id);
+  res.json({ ok: true });
+});
+```
+
+To correlate a request with library-triggered side effects (e.g. [lifecycle hooks](#lifecycle-hooks)), capture `req.id` in your own route before calling into the library, and include it when logging or calling `onUserCreated`/`sendPasswordReset`/etc. from your app code.
+
 ## Build Checks
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -435,6 +435,24 @@ app.use(lib.router);
 
 Send `Idempotency-Key: <uuid>` on the request. The first call runs normally and its response is stored; any repeat with the same key returns the exact same response (marked with an `Idempotent-Replay: true` header) without re-executing the handler. Requests without the header are unaffected — idempotency is opt-in per call. The `idempotent(store, options?)` middleware is also exported standalone for use on your own routes.
 
+## Bulk User Lookup
+
+`POST /users/batch` resolves multiple users in a single call, for services that would otherwise fire N parallel `GET /users/:id` requests:
+
+```http
+POST /users/batch
+Authorization: Bearer <admin accessToken>
+Content-Type: application/json
+
+{ "ids": [1, 2, 3] }
+```
+
+```json
+{ "items": [ { "id": 1, "email": "...", ... }, { "id": 2, "email": "...", ... } ] }
+```
+
+Unmatched ids are silently omitted rather than causing an error. Requires an `ADMIN` token and, like `GET /users`, is automatically scoped to the admin's `tenantId` when present. Accepts up to 100 ids per call. `UserRepo.findManyByIds` is optional on custom adapters — when absent, the service falls back to N `findById` calls, so existing adapters keep working unchanged.
+
 ## Build Checks
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -358,6 +358,30 @@ import {
 - `mapKnownError(err)` normalizes any thrown value (a plain `Error`, a `ZodError`, or an `AppError`) into an `AppError` with a stable `code` and `statusCode`; Zod issues are formatted into `details` via `formatZodIssues`.
 - `formatZodIssues(issues)` flattens `ZodIssue[]` into `{ field, message }[]` directly, for use with your own Zod schemas outside this library's routes.
 
+## Multi-Tenancy (SaaS)
+
+An optional `tenantId` scopes users to a tenant/organization, for SaaS deployments that share one database across customers:
+
+```ts
+import { requireTenant, isSameTenant } from "my-crud-lib/middleware";
+
+// register/create accept an optional tenantId
+await service.registerUser({ email, password, tenantId: "tenant-a" });
+
+// tenantId is embedded in access/refresh tokens and available as req.user.tenantId
+app.get("/internal/reports", isAuth, requireTenant(), handler);
+```
+
+Behavior:
+- `POST /auth/register` and `POST /users` accept an optional `tenantId`.
+- Access/refresh tokens carry `tenantId` when the user has one; `isAuth` exposes it as `req.user.tenantId`.
+- Admin `GET /users` is automatically scoped to `req.user.tenantId` when the admin's token carries one — an admin token scoped to a tenant can never list another tenant's users.
+- `GET/PUT/DELETE /users/:id` respond `404` (not `403`, to avoid leaking existence) when the target user belongs to a different tenant.
+- `requireTenant()` middleware rejects requests from tokens without a `tenantId`.
+- `isSameTenant(getResourceTenantId?)` middleware compares `req.user.tenantId` against a resolved resource tenant id (defaults to `req.params.tenantId`), for your own routes.
+
+Single-tenant apps are unaffected: omit `tenantId` everywhere and behavior is identical to before.
+
 ## Build Checks
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -382,6 +382,26 @@ Behavior:
 
 Single-tenant apps are unaffected: omit `tenantId` everywhere and behavior is identical to before.
 
+## API Keys (Machine-to-Machine Auth)
+
+For requests between internal services (workers, schedulers, other microservices) that don't have a user behind them:
+
+```ts
+import { issueApiKey, isApiKey } from "my-crud-lib";
+import { makeMemoryApiKeyRepo } from "my-crud-lib/adapters/memory"; // or makePrismaApiKeyRepo
+
+const apiKeyRepo = makeMemoryApiKeyRepo();
+
+// generate once, e.g. from an admin script; store the returned key securely — it is never retrievable again
+const { key } = await issueApiKey(apiKeyRepo, { name: "billing-service", scopes: ["users:read"] });
+
+app.get("/internal/users/:id", isApiKey(apiKeyRepo, { requiredScopes: ["users:read"] }), handler);
+```
+
+The caller sends the key back via `X-API-Key: <key>` or `Authorization: ApiKey <key>`. Only a salted hash of the key is ever persisted (via `ApiKeyRepo`); the plaintext is returned once from `issueApiKey` and cannot be recovered afterward. `isApiKey` attaches `req.apiKey = { id, name, scopes, tenantId? }` on success.
+
+To require either a user token or a service API key on the same route, chain your own small middleware that tries `isAuth` and falls back to `isApiKey`.
+
 ## Build Checks
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -488,6 +488,21 @@ app.get("/whoami", (req, res) => {
 
 To correlate a request with library-triggered side effects (e.g. [lifecycle hooks](#lifecycle-hooks)), capture `req.id` in your own route before calling into the library, and include it when logging or calling `onUserCreated`/`sendPasswordReset`/etc. from your app code.
 
+## Health Checks
+
+`createLibrary`/`mountDefaultRoutes` mount `GET /health` and `GET /ready` (unprefixed, by convention) by default — useful for orchestrator probes (Kubernetes, ECS, etc.):
+
+- `GET /health` — liveness, always `200 { "status": "ok" }`, no dependencies checked.
+- `GET /ready` — readiness, calls `userRepo.count({})`; `200 { "status": "ok" }` if it resolves, `503 { "status": "error", "error": "..." }` if it throws (e.g. the database is unreachable).
+
+Disable them with `health: false` if your app already defines these routes:
+
+```ts
+createLibrary({ health: false }, { userRepo });
+```
+
+`createHealthRouter({ userRepo })` is also exported standalone.
+
 ## Build Checks
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -508,6 +508,7 @@ createLibrary({ health: false }, { userRepo });
 ```bash
 npm run build
 npm test
+npm run test:api
 npm run smoke:exports
 npm run smoke:auth-hardening
 npm run smoke:auth-service
@@ -516,6 +517,7 @@ npm run smoke:auth-service
 `smoke:exports` builds the package and imports the documented public paths from `dist`.
 `smoke:auth-hardening` checks auth safety defaults and JWT secret validation.
 `smoke:auth-service` verifies register/login/refresh/me with an in-memory repo.
+`test:api` runs the Jest + Supertest end-to-end API suite (`tests/api/`) against a real HTTP server backed by the in-memory adapter, covering every route mounted by `createLibrary` — success paths, validation (400), auth (401), permissions (403), not found (404), and conflicts (409). It runs automatically in CI on every pull request.
 
 ## Current Limitations
 

--- a/README.md
+++ b/README.md
@@ -417,6 +417,24 @@ With `JWT_ALG=RS256`, `createLibrary`/`mountDefaultRoutes` automatically mount `
 
 `JWT_PRIVATE_KEY`/`JWT_PUBLIC_KEY` accept PEM content directly, or with literal `\n` sequences (common when stored as a single-line CI/CD secret).
 
+## Idempotency Keys
+
+For clients that retry on timeout or fire the same intent from multiple parallel callers (common with async workers and microservice retries), `POST /auth/register` and `POST /users` can replay a stored response instead of running twice:
+
+```ts
+import { createLibrary, createServer } from "my-crud-lib";
+import { makeMemoryIdempotencyStore } from "my-crud-lib/adapters/memory"; // or makePrismaIdempotencyStore
+
+const app = createServer();
+const lib = createLibrary(
+  { routesPrefix: "/api" },
+  { userRepo, idempotencyStore: makeMemoryIdempotencyStore() }
+);
+app.use(lib.router);
+```
+
+Send `Idempotency-Key: <uuid>` on the request. The first call runs normally and its response is stored; any repeat with the same key returns the exact same response (marked with an `Idempotent-Replay: true` header) without re-executing the handler. Requests without the header are unaffected — idempotency is opt-in per call. The `idempotent(store, options?)` middleware is also exported standalone for use on your own routes.
+
 ## Build Checks
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -402,6 +402,21 @@ The caller sends the key back via `X-API-Key: <key>` or `Authorization: ApiKey <
 
 To require either a user token or a service API key on the same route, chain your own small middleware that tries `isAuth` and falls back to `isApiKey`.
 
+## Asymmetric JWTs (RS256/JWKS)
+
+By default tokens are signed with `JWT_SECRET` (HS256), which every service that verifies tokens must also hold. For a microservices setup, sign with a private key in the auth service and let other services verify with the public key alone, via a standard JWKS endpoint:
+
+```bash
+JWT_ALG="RS256"
+JWT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
+JWT_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----"
+JWT_KEY_ID="2026-01"   # optional, defaults to "default"; bump when rotating keys
+```
+
+With `JWT_ALG=RS256`, `createLibrary`/`mountDefaultRoutes` automatically mount `GET /.well-known/jwks.json` (unprefixed, per convention) publishing the public key as a JWK. Other services can fetch it and verify tokens with any standard JWT/JWKS library — no shared secret required. `JWT_SECRET` is not needed in this mode.
+
+`JWT_PRIVATE_KEY`/`JWT_PUBLIC_KEY` accept PEM content directly, or with literal `\n` sequences (common when stored as a single-line CI/CD secret).
+
 ## Build Checks
 
 ```bash

--- a/examples/express-prisma/prisma/schema.prisma
+++ b/examples/express-prisma/prisma/schema.prisma
@@ -94,3 +94,15 @@ enum Role {
   USER
   ADMIN
 }
+
+model ApiKey {
+  id        String    @id
+  name      String?
+  keyHash   String
+  scopes    String[]  @default([])
+  tenantId  String?
+  revokedAt DateTime?
+  createdAt DateTime  @default(now())
+
+  @@index([tenantId])
+}

--- a/examples/express-prisma/prisma/schema.prisma
+++ b/examples/express-prisma/prisma/schema.prisma
@@ -106,3 +106,11 @@ model ApiKey {
 
   @@index([tenantId])
 }
+
+model IdempotencyKey {
+  key       String    @id
+  status    Int
+  body      Json
+  expiresAt DateTime?
+  createdAt DateTime  @default(now())
+}

--- a/examples/express-prisma/prisma/schema.prisma
+++ b/examples/express-prisma/prisma/schema.prisma
@@ -13,6 +13,7 @@ model User {
   passwordHash            String
   name                    String?
   role                    Role                     @default(USER)
+  tenantId                String?
   emailVerifiedAt         DateTime?
   createdAt               DateTime                 @default(now())
   updatedAt               DateTime                 @updatedAt
@@ -21,6 +22,8 @@ model User {
   passwordResetTokens     PasswordResetToken[]
   emailVerificationTokens EmailVerificationToken[]
   oauthAccounts           OauthAccount[]
+
+  @@index([tenantId])
 }
 
 model Profile {

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('jest').Config} */
+export default {
+  testEnvironment: 'node',
+  testMatch: ['**/tests/api/**/*.test.js'],
+  transform: {},
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "my-crud-lib",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "my-crud-lib",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "bcryptjs": "^2.4.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,9 @@
         "@types/express": "^5.0.3",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^24.3.0",
+        "jest": "^30.4.2",
         "prisma": "^6.14.0",
+        "supertest": "^7.2.2",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.2"
       },
@@ -47,6 +49,583 @@
         }
       }
     },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/core/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
+      "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -58,6 +637,503 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.4.1.tgz",
+      "integrity": "sha512-v3bhyxUh9Hgmo5p6hAOXe14/R3ZxZDOsvHleh4B07z3m/x4/ngPUXEm9XwK4sF4u+f+P2ORb0Ge+MgpaqRMVDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.4.2.tgz",
+      "integrity": "sha512-TZJA6cPJUFxoWhxaLo8t0VX/MZX2wPWr0uIDvLSHIvN4gu9h02vSzqI2kBADG1ExqQlC+cY09xKMSreivvrChQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "30.4.1",
+        "@jest/pattern": "30.4.0",
+        "@jest/reporters": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "exit-x": "^0.2.2",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.11",
+        "jest-changed-files": "30.4.1",
+        "jest-config": "30.4.2",
+        "jest-haste-map": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-resolve": "30.4.1",
+        "jest-resolve-dependencies": "30.4.2",
+        "jest-runner": "30.4.2",
+        "jest-runtime": "30.4.2",
+        "jest-snapshot": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
+        "jest-watcher": "30.4.1",
+        "pretty-format": "30.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+      "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
+      "integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-mock": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.4.1.tgz",
+      "integrity": "sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "30.4.1",
+        "jest-snapshot": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
+      "integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
+      "integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@sinonjs/fake-timers": "^15.4.0",
+        "@types/node": "*",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.4.1.tgz",
+      "integrity": "sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.4.1",
+        "@jest/expect": "30.4.1",
+        "@jest/types": "30.4.1",
+        "jest-mock": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+      "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.4.1.tgz",
+      "integrity": "sha512-/SnkPCzEQpUaBH81kjdEdDdo2WZl5hxw+BmLDGWjRkm8o7XlhjwsU36cqwe5PGBE5WYpBvDzRSdXx9rbGuJtNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "collect-v8-coverage": "^1.0.2",
+        "exit-x": "^0.2.2",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^5.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-worker": "30.4.1",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.2",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/snapshot-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.4.1.tgz",
+      "integrity": "sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "natural-compare": "^1.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-30.0.1.tgz",
+      "integrity": "sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "callsites": "^3.1.0",
+        "graceful-fs": "^4.2.11"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/source-map/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.4.1.tgz",
+      "integrity": "sha512-/ZG7pgEiOmmWkN9TplKbOu4id2N5lh7FHwRwlkgBVAzGdRH+OkkQ8wX/kIxg4zmd3ZQvAL1RwL2yWsvNYYECTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "collect-v8-coverage": "^1.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.4.1.tgz",
+      "integrity": "sha512-PeYE+4td5rKjoRPxztObrXU+H8hsjZfxKMXOcmrr34JerSyB/ROOxbbicz8B7A5j9R9VayDnVPvBmedqCsFCdw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "30.4.1",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.4.1.tgz",
+      "integrity": "sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@jest/types": "30.4.1",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "babel-plugin-istanbul": "^7.0.1",
+        "chalk": "^4.1.2",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-util": "30.4.1",
+        "pirates": "^4.0.7",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^5.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/transform/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+      "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.4.0",
+        "@jest/schemas": "30.4.1",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -86,6 +1162,72 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
+      "integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
       }
     },
     "node_modules/@prisma/client": {
@@ -174,6 +1316,33 @@
         "@prisma/debug": "6.14.0"
       }
     },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.52",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
+      "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "15.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+      "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
@@ -208,6 +1377,62 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
     },
     "node_modules/@types/bcryptjs": {
       "version": "2.4.6",
@@ -278,6 +1503,33 @@
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
     },
     "node_modules/@types/jsonwebtoken": {
       "version": "9.0.10",
@@ -351,6 +1603,380 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.12.2.tgz",
+      "integrity": "sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.12.2.tgz",
+      "integrity": "sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.12.2.tgz",
+      "integrity": "sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.12.2.tgz",
+      "integrity": "sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.12.2.tgz",
+      "integrity": "sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.2.tgz",
+      "integrity": "sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.2.tgz",
+      "integrity": "sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.2.tgz",
+      "integrity": "sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.12.2.tgz",
+      "integrity": "sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-loong64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-gnu/-/resolver-binding-linux-loong64-gnu-1.12.2.tgz",
+      "integrity": "sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-loong64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-musl/-/resolver-binding-linux-loong64-musl-1.12.2.tgz",
+      "integrity": "sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.12.2.tgz",
+      "integrity": "sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.12.2.tgz",
+      "integrity": "sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.12.2.tgz",
+      "integrity": "sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.12.2.tgz",
+      "integrity": "sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.2.tgz",
+      "integrity": "sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.12.2.tgz",
+      "integrity": "sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-openharmony-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-openharmony-arm64/-/resolver-binding-openharmony-arm64-1.12.2.tgz",
+      "integrity": "sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.12.2.tgz",
+      "integrity": "sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
+      "integrity": "sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.12.2.tgz",
+      "integrity": "sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.2.tgz",
+      "integrity": "sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -391,6 +2017,78 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -398,12 +2096,155 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/babel-jest": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.4.1.tgz",
+      "integrity": "sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "30.4.1",
+        "@types/babel__core": "^7.20.5",
+        "babel-plugin-istanbul": "^7.0.1",
+        "babel-preset-jest": "30.4.0",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
+      "integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "workspaces": [
+        "test/babel-8"
+      ],
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-instrument": "^6.0.2",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.4.0.tgz",
+      "integrity": "sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/babel__core": "^7.20.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.4.0.tgz",
+      "integrity": "sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "30.4.0",
+        "babel-preset-current-node-syntax": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.1.tgz",
+      "integrity": "sha512-HYXq73DDpCtNzOmrFsm9eSwCvWCql0RzqjpDzXN9EadiLJ4DNat0nsZ/Bzmy+Ud12mb4/zKDY0cQ805ZzN+i0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/bcryptjs": {
       "version": "2.4.3",
@@ -436,11 +2277,72 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-int64": "^0.4.0"
+      }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -486,7 +2388,6 @@
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -500,7 +2401,6 @@
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -510,6 +2410,74 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/chokidar": {
@@ -528,6 +2496,22 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/citty": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
@@ -537,6 +2521,159 @@
       "dependencies": {
         "consola": "^3.2.3"
       }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/confbox": {
       "version": "0.2.2",
@@ -578,6 +2715,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cookie": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
@@ -594,6 +2738,13 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cors": {
       "version": "2.8.5",
@@ -616,6 +2767,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -624,6 +2790,31 @@
       "peer": true,
       "dependencies": {
         "ms": "2.0.0"
+      }
+    },
+    "node_modules/dedent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/deepmerge-ts": {
@@ -642,6 +2833,16 @@
       "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -671,6 +2872,27 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -698,7 +2920,6 @@
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -707,6 +2928,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -735,6 +2963,33 @@
         "fast-check": "^3.23.1"
       }
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.396",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.396.tgz",
+      "integrity": "sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/empathic": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
@@ -755,12 +3010,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -770,7 +3034,6 @@
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -780,12 +3043,37 @@
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-html": {
@@ -795,6 +3083,30 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -803,6 +3115,65 @@
       "peer": true,
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/exit-x": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz",
+      "integrity": "sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
+      "integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "30.4.1",
+        "@jest/get-type": "30.1.0",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/express": {
@@ -882,6 +3253,30 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bser": "2.1.1"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
@@ -899,6 +3294,72 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -921,14 +3382,55 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -936,7 +3438,6 @@
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -956,18 +3457,40 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/giget": {
@@ -988,12 +3511,33 @@
         "giget": "dist/cli.mjs"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -1001,12 +3545,44 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
-      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -1015,17 +3591,23 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -1044,6 +3626,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -1057,12 +3649,53 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -1074,6 +3707,773 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/istanbul-lib-source-maps/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jest": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-30.4.2.tgz",
+      "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "30.4.2",
+        "@jest/types": "30.4.1",
+        "import-local": "^3.2.0",
+        "jest-cli": "30.4.2"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.4.1.tgz",
+      "integrity": "sha512-IuctmYrxi21iOSOaIXpJWalHyPAsVv0GeBHKDn8C1CA4W5htHn7INL+wdnL4Bo0+olEndvAFkmb++tIQJG+vvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.1.1",
+        "jest-util": "30.4.1",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.4.2.tgz",
+      "integrity": "sha512-rvHH7VlY6LgbJXJTQ87GW62g1FntOtbhh0zT+v04kC+pgL6aBKyYINXxWukCpj3dcIBMw5/XUbtDS9dU9JTXeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.4.1",
+        "@jest/expect": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "co": "^4.6.0",
+        "dedent": "^1.6.0",
+        "is-generator-fn": "^2.1.0",
+        "jest-each": "30.4.1",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-runtime": "30.4.2",
+        "jest-snapshot": "30.4.1",
+        "jest-util": "30.4.1",
+        "p-limit": "^3.1.0",
+        "pretty-format": "30.4.1",
+        "pure-rand": "^7.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/pure-rand": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/jest-cli": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.4.2.tgz",
+      "integrity": "sha512-jfA2ocvVHMXS2QijrJ0d31ektP+d/W0T5RpcTX2Pq+3sVqHlsXVCM2+FmwpL+bdY8OfHpIg9xMxLF17Zg0U49Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "30.4.2",
+        "@jest/test-result": "30.4.1",
+        "@jest/types": "30.4.1",
+        "chalk": "^4.1.2",
+        "exit-x": "^0.2.2",
+        "import-local": "^3.2.0",
+        "jest-config": "30.4.2",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.4.2.tgz",
+      "integrity": "sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@jest/get-type": "30.1.0",
+        "@jest/pattern": "30.4.0",
+        "@jest/test-sequencer": "30.4.1",
+        "@jest/types": "30.4.1",
+        "babel-jest": "30.4.1",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "deepmerge": "^4.3.1",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "jest-circus": "30.4.2",
+        "jest-docblock": "30.4.0",
+        "jest-environment-node": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-resolve": "30.4.1",
+        "jest-runner": "30.4.2",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
+        "parse-json": "^5.2.0",
+        "pretty-format": "30.4.1",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "esbuild-register": ">=3.4.0",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "esbuild-register": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+      "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.4.0",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.4.0.tgz",
+      "integrity": "sha512-ZPMabUZCx5MpbZ2eBYSvZ0J8fvo3dR9oM+eeUpb3aKNQFuS2tu3Duw1TNlMoP8k3WQgKGJuhcMFvwcVuq6T7oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.4.1.tgz",
+      "integrity": "sha512-/8MJbH6fuj48TstjrMf+u/pd06Qezz5xOXvZA6442heNOWr8bdeoGZX2d9fCn028CoMgYmroH9//zky5GfyYmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "@jest/types": "30.4.1",
+        "chalk": "^4.1.2",
+        "jest-util": "30.4.1",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.4.1.tgz",
+      "integrity": "sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.4.1",
+        "@jest/fake-timers": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.4.1.tgz",
+      "integrity": "sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "anymatch": "^3.1.3",
+        "fb-watchman": "^2.0.2",
+        "graceful-fs": "^4.2.11",
+        "jest-regex-util": "30.4.0",
+        "jest-util": "30.4.1",
+        "jest-worker": "30.4.1",
+        "picomatch": "^4.0.3",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.3"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.4.1.tgz",
+      "integrity": "sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+      "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.4.1",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+      "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.4.1",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-util": "30.4.1",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.4.1",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+      "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+      "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.4.1.tgz",
+      "integrity": "sha512-Zry8Yq/yJcNAZ7dJ5F2heic8AheXvbFZ7XI5V+h28nrYZ7Qoyy4dItq8OodjnYD270mvX+ZudmrNV9cysqhW5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.4.1",
+        "jest-pnp-resolver": "^1.2.3",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
+        "slash": "^3.0.0",
+        "unrs-resolver": "^1.7.11"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.4.2.tgz",
+      "integrity": "sha512-gDiVh1I+GxYzz9oXlyw+1wv6VOYX1WYxMOfjsA3iGKePV2oxmbHhwxfkALxNxYy1ciw6APWwkW2zZONwP97aEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "30.4.0",
+        "jest-snapshot": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.4.2.tgz",
+      "integrity": "sha512-2dw0PslVYXxffXGpLo+Ejad+KcI1Qkjn7f4X4619gf21oCUmL+SPfjqIa/losUem3yEOvfNZe/F1HWUcNpODcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "30.4.1",
+        "@jest/environment": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "emittery": "^0.13.1",
+        "exit-x": "^0.2.2",
+        "graceful-fs": "^4.2.11",
+        "jest-docblock": "30.4.0",
+        "jest-environment-node": "30.4.1",
+        "jest-haste-map": "30.4.1",
+        "jest-leak-detector": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-resolve": "30.4.1",
+        "jest-runtime": "30.4.2",
+        "jest-util": "30.4.1",
+        "jest-watcher": "30.4.1",
+        "jest-worker": "30.4.1",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.4.2.tgz",
+      "integrity": "sha512-3/5e8iPz2k/VLqlr8DgTftYyLUv8Su3FkCAO2/Od81UsUTpSxOrS6O5x5KkoQwyUjmpYyDJKeyAvg2T2nvpNkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.4.1",
+        "@jest/fake-timers": "30.4.1",
+        "@jest/globals": "30.4.1",
+        "@jest/source-map": "30.0.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "cjs-module-lexer": "^2.1.0",
+        "collect-v8-coverage": "^1.0.2",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-resolve": "30.4.1",
+        "jest-snapshot": "30.4.1",
+        "jest-util": "30.4.1",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.4.1.tgz",
+      "integrity": "sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@babel/generator": "^7.27.5",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.27.1",
+        "@babel/types": "^7.27.3",
+        "@jest/expect-utils": "30.4.1",
+        "@jest/get-type": "30.1.0",
+        "@jest/snapshot-utils": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "babel-preset-current-node-syntax": "^1.2.0",
+        "chalk": "^4.1.2",
+        "expect": "30.4.1",
+        "graceful-fs": "^4.2.11",
+        "jest-diff": "30.4.1",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
+        "pretty-format": "30.4.1",
+        "semver": "^7.7.2",
+        "synckit": "^0.11.8"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+      "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.4.1.tgz",
+      "integrity": "sha512-PDWi4SOwLnwqNDfHZjOcsEFyZ4fc/2W2gVL3DEoyqnB6jCQMLRtfBong8s6omIw3lI0HWOus12xfnFmQtjW3fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "@jest/types": "30.4.1",
+        "camelcase": "^6.3.0",
+        "chalk": "^4.1.2",
+        "leven": "^3.1.0",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.4.1.tgz",
+      "integrity": "sha512-/l9UonmvCwjHH7d2h3iAwIloLc1H0S8mJZ/LNK3i86hqwPAz8otUJjP9MfYtz9Tt77Su5FD2xGjZn8d31IZHlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "emittery": "^0.13.1",
+        "jest-util": "30.4.1",
+        "string-length": "^4.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.4.1.tgz",
+      "integrity": "sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@ungap/structured-clone": "^1.3.0",
+        "jest-util": "30.4.1",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.1.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
@@ -1082,6 +4482,60 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/jsonwebtoken": {
@@ -1133,6 +4587,36 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -1175,6 +4659,32 @@
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -1182,12 +4692,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/makeerror": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tmpl": "1.0.5"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -1212,12 +4731,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1240,7 +4765,6 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1250,12 +4774,47 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -1264,6 +4823,29 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -1281,6 +4863,46 @@
       "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/nypm": {
       "version": "0.6.1",
@@ -1317,7 +4939,6 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -1345,6 +4966,113 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1354,6 +5082,60 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.12",
@@ -1376,6 +5158,49 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/pkg-types": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
@@ -1386,6 +5211,35 @@
         "confbox": "^0.2.2",
         "exsolve": "^1.0.7",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/prisma": {
@@ -1498,6 +5352,22 @@
         "destr": "^2.0.3"
       }
     },
+    "node_modules/react-is-18": {
+      "name": "react-is",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-is-19": {
+      "name": "react-is",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+      "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -1510,6 +5380,39 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/safe-buffer": {
@@ -1616,16 +5519,38 @@
       "license": "ISC",
       "peer": true
     },
-    "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -1637,14 +5562,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1658,7 +5582,6 @@
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -1677,7 +5600,6 @@
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -1692,6 +5614,70 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -1702,12 +5688,384 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-length/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-length/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/superagent/node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/synckit": {
+      "version": "0.11.13",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
+      "integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.3.6"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/tinyexec": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
       "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
@@ -1763,6 +6121,37 @@
         }
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -1808,6 +6197,75 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/unrs-resolver": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
+      "integrity": "sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "napi-postinstall": "^0.3.4"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.12.2",
+        "@unrs/resolver-binding-android-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-x64": "1.12.2",
+        "@unrs/resolver-binding-freebsd-x64": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-musl": "1.12.2",
+        "@unrs/resolver-binding-openharmony-arm64": "1.12.2",
+        "@unrs/resolver-binding-wasm32-wasi": "1.12.2",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -1825,6 +6283,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/v8-to-istanbul/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -1835,6 +6319,239 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/walker": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
@@ -1843,6 +6560,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,8 @@
     "prebuild": "node scripts/prisma-generate.mjs",
     "build": "tsc",
     "test": "npm run build && node --test tests/*.test.mjs",
-    "ci": "npm test && npm run smoke:exports && npm run smoke:auth-hardening && npm run smoke:auth-service && npm --cache .npm-cache pack --dry-run",
+    "test:api": "npm run build && node --experimental-vm-modules node_modules/.bin/jest --config jest.config.mjs",
+    "ci": "npm test && npm run test:api && npm run smoke:exports && npm run smoke:auth-hardening && npm run smoke:auth-service && npm --cache .npm-cache pack --dry-run",
     "start": "node dist/index.js",
     "dev": "node --loader ts-node/esm --no-warnings=ExperimentalWarning src/dev.ts",
     "dev:db:up": "docker-compose up -d",
@@ -111,13 +112,15 @@
     "generate:secret": "node scripts/generateSecret.js"
   },
   "devDependencies": {
+    "@prisma/client": "^6.14.0",
     "@types/bcryptjs": "^2.4.6",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^24.3.0",
+    "jest": "^30.4.2",
     "prisma": "^6.14.0",
-    "@prisma/client": "^6.14.0",
+    "supertest": "^7.2.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.2"
   },
@@ -128,10 +131,10 @@
     "zod": "^3.23.8"
   },
   "peerDependencies": {
-    "express": "^4.18.2",
-    "cors": "^2.8.5",
-    "body-parser": "^1.20.2",
     "@prisma/client": "^6.14.0",
+    "body-parser": "^1.20.2",
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
     "prisma": "^6.14.0"
   },
   "peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-crud-lib",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "TypeScript auth and user/profile CRUD helpers for Express with Prisma and custom repository adapters",
   "license": "MIT",
   "author": "Riccardo Sensi",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -94,3 +94,15 @@ enum Role {
   USER
   ADMIN
 }
+
+model ApiKey {
+  id        String    @id
+  name      String?
+  keyHash   String
+  scopes    String[]  @default([])
+  tenantId  String?
+  revokedAt DateTime?
+  createdAt DateTime  @default(now())
+
+  @@index([tenantId])
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -106,3 +106,11 @@ model ApiKey {
 
   @@index([tenantId])
 }
+
+model IdempotencyKey {
+  key       String    @id
+  status    Int
+  body      Json
+  expiresAt DateTime?
+  createdAt DateTime  @default(now())
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,6 +13,7 @@ model User {
   passwordHash            String
   name                    String?
   role                    Role                     @default(USER)
+  tenantId                String?
   emailVerifiedAt         DateTime?
   createdAt               DateTime                 @default(now())
   updatedAt               DateTime                 @updatedAt
@@ -21,6 +22,8 @@ model User {
   passwordResetTokens     PasswordResetToken[]
   emailVerificationTokens EmailVerificationToken[]
   oauthAccounts           OauthAccount[]
+
+  @@index([tenantId])
 }
 
 model Profile {

--- a/src/adapter-memory.ts
+++ b/src/adapter-memory.ts
@@ -1,1 +1,1 @@
-export { makeMemoryUserRepo } from './adapters/memory.js';
+export { makeMemoryApiKeyRepo, makeMemoryUserRepo } from './adapters/memory.js';

--- a/src/adapter-memory.ts
+++ b/src/adapter-memory.ts
@@ -1,1 +1,1 @@
-export { makeMemoryApiKeyRepo, makeMemoryUserRepo } from './adapters/memory.js';
+export { makeMemoryApiKeyRepo, makeMemoryIdempotencyStore, makeMemoryUserRepo } from './adapters/memory.js';

--- a/src/adapter-memory.ts
+++ b/src/adapter-memory.ts
@@ -1,1 +1,6 @@
-export { makeMemoryApiKeyRepo, makeMemoryIdempotencyStore, makeMemoryUserRepo } from './adapters/memory.js';
+export {
+  makeMemoryApiKeyRepo,
+  makeMemoryIdempotencyStore,
+  makeMemoryRateLimiter,
+  makeMemoryUserRepo,
+} from './adapters/memory.js';

--- a/src/adapter-prisma.ts
+++ b/src/adapter-prisma.ts
@@ -1,6 +1,7 @@
 export {
   makePrismaApiKeyRepo,
   makePrismaEmailVerificationTokenRepo,
+  makePrismaIdempotencyStore,
   makePrismaOAuthAccountRepo,
   makePrismaPasswordResetTokenRepo,
   makePrismaRefreshTokenRepo,

--- a/src/adapter-prisma.ts
+++ b/src/adapter-prisma.ts
@@ -1,4 +1,5 @@
 export {
+  makePrismaApiKeyRepo,
   makePrismaEmailVerificationTokenRepo,
   makePrismaOAuthAccountRepo,
   makePrismaPasswordResetTokenRepo,

--- a/src/adapters/memory.ts
+++ b/src/adapters/memory.ts
@@ -1,4 +1,5 @@
 import type { UserRepo } from '../core/ports/user.repo.js';
+import type { ApiKeyRecord, ApiKeyRepo } from '../core/ports/apiKey.repo.js';
 import type { AdminUpdateUserInput, Role, UserListItem } from '../modules/user/user.types.js';
 
 type StoredUser = UserListItem & { passwordHash: string };
@@ -126,6 +127,37 @@ export function makeMemoryUserRepo(): UserRepo {
       const updated: StoredUser = { ...user, emailVerifiedAt: verifiedAt, updatedAt: new Date().toISOString() };
       users.set(Number(id), updated);
       return toPublic(updated);
+    },
+  };
+}
+
+/** In-memory `ApiKeyRepo` implementation. Useful for demos, prototyping, and tests. */
+export function makeMemoryApiKeyRepo(): ApiKeyRepo {
+  const keys = new Map<string, ApiKeyRecord>();
+
+  return {
+    async findById(id) {
+      return keys.get(id) ?? null;
+    },
+
+    async create(input) {
+      const record: ApiKeyRecord = {
+        id: input.id,
+        name: input.name ?? null,
+        keyHash: input.keyHash,
+        scopes: input.scopes ?? [],
+        tenantId: input.tenantId ?? null,
+        revokedAt: null,
+        createdAt: new Date().toISOString(),
+      };
+      keys.set(record.id, record);
+      return record;
+    },
+
+    async revoke(id, input = {}) {
+      const record = keys.get(id);
+      if (!record) return;
+      keys.set(id, { ...record, revokedAt: input.revokedAt ?? new Date() });
     },
   };
 }

--- a/src/adapters/memory.ts
+++ b/src/adapters/memory.ts
@@ -1,6 +1,7 @@
 import type { UserRepo } from '../core/ports/user.repo.js';
 import type { ApiKeyRecord, ApiKeyRepo } from '../core/ports/apiKey.repo.js';
 import type { IdempotencyRecord, IdempotencyStore } from '../core/ports/idempotency.repo.js';
+import type { RateLimiter } from '../core/ports/rateLimiter.repo.js';
 import type { AdminUpdateUserInput, Role, UserListItem } from '../modules/user/user.types.js';
 
 type StoredUser = UserListItem & { passwordHash: string };
@@ -188,6 +189,35 @@ export function makeMemoryIdempotencyStore(): IdempotencyStore {
         ...record,
         expiresAt: ttlMs !== undefined ? Date.now() + ttlMs : null,
       });
+    },
+  };
+}
+
+/**
+ * In-memory fixed-window `RateLimiter`: allows up to `points` calls per `key`
+ * within each `durationMs` window. Per-process only — use a shared store
+ * (Redis, a database) to enforce one limit across multiple instances.
+ */
+export function makeMemoryRateLimiter(options: { points: number; durationMs: number }): RateLimiter {
+  const windows = new Map<string, { count: number; resetAt: number }>();
+
+  return {
+    async consume(key, cost = 1) {
+      const now = Date.now();
+      const window = windows.get(key);
+
+      if (!window || window.resetAt <= now) {
+        const resetAt = now + options.durationMs;
+        windows.set(key, { count: cost, resetAt });
+        return { allowed: cost <= options.points, remaining: Math.max(options.points - cost, 0) };
+      }
+
+      if (window.count + cost > options.points) {
+        return { allowed: false, remaining: Math.max(options.points - window.count, 0), retryAfterMs: window.resetAt - now };
+      }
+
+      window.count += cost;
+      return { allowed: true, remaining: options.points - window.count };
     },
   };
 }

--- a/src/adapters/memory.ts
+++ b/src/adapters/memory.ts
@@ -8,8 +8,9 @@ function toPublic(user: StoredUser): UserListItem {
   return safeUser;
 }
 
-function matchesFilters(user: StoredUser, role?: string, search?: string): boolean {
+function matchesFilters(user: StoredUser, role?: string, search?: string, tenantId?: string | number): boolean {
   if (role && user.role !== role) return false;
+  if (tenantId !== undefined && String(user.tenantId ?? '') !== String(tenantId)) return false;
   if (search?.trim()) {
     const needle = search.trim().toLowerCase();
     const haystack = `${user.email} ${user.name ?? ''}`.toLowerCase();
@@ -35,13 +36,13 @@ export function makeMemoryUserRepo(): UserRepo {
   let nextId = 1;
 
   return {
-    async count({ role, search } = {}) {
-      return [...users.values()].filter((u) => matchesFilters(u, role, search)).length;
+    async count({ role, search, tenantId } = {}) {
+      return [...users.values()].filter((u) => matchesFilters(u, role, search, tenantId)).length;
     },
 
-    async findMany({ page, pageSize, role, search, sortField, sortDir }) {
+    async findMany({ page, pageSize, role, search, tenantId, sortField, sortDir }) {
       const filtered = [...users.values()]
-        .filter((u) => matchesFilters(u, role, search))
+        .filter((u) => matchesFilters(u, role, search, tenantId))
         .sort((a, b) => compare(a, b, sortField, sortDir));
       return filtered.slice((page - 1) * pageSize, page * pageSize).map(toPublic);
     },
@@ -64,6 +65,7 @@ export function makeMemoryUserRepo(): UserRepo {
         passwordHash: input.passwordHash,
         name: input.name ?? null,
         role: (input.role as Role) === 'ADMIN' ? 'ADMIN' : 'USER',
+        tenantId: input.tenantId ?? null,
         emailVerifiedAt: null,
         createdAt: now,
         updatedAt: now,

--- a/src/adapters/memory.ts
+++ b/src/adapters/memory.ts
@@ -1,5 +1,6 @@
 import type { UserRepo } from '../core/ports/user.repo.js';
 import type { ApiKeyRecord, ApiKeyRepo } from '../core/ports/apiKey.repo.js';
+import type { IdempotencyRecord, IdempotencyStore } from '../core/ports/idempotency.repo.js';
 import type { AdminUpdateUserInput, Role, UserListItem } from '../modules/user/user.types.js';
 
 type StoredUser = UserListItem & { passwordHash: string };
@@ -158,6 +159,30 @@ export function makeMemoryApiKeyRepo(): ApiKeyRepo {
       const record = keys.get(id);
       if (!record) return;
       keys.set(id, { ...record, revokedAt: input.revokedAt ?? new Date() });
+    },
+  };
+}
+
+/** In-memory `IdempotencyStore` implementation. Useful for demos, prototyping, and tests. */
+export function makeMemoryIdempotencyStore(): IdempotencyStore {
+  const records = new Map<string, IdempotencyRecord & { expiresAt: number | null }>();
+
+  return {
+    async get(key) {
+      const record = records.get(key);
+      if (!record) return null;
+      if (record.expiresAt !== null && record.expiresAt <= Date.now()) {
+        records.delete(key);
+        return null;
+      }
+      return { status: record.status, body: record.body };
+    },
+
+    async set(key, record, ttlMs) {
+      records.set(key, {
+        ...record,
+        expiresAt: ttlMs !== undefined ? Date.now() + ttlMs : null,
+      });
     },
   };
 }

--- a/src/adapters/memory.ts
+++ b/src/adapters/memory.ts
@@ -54,6 +54,11 @@ export function makeMemoryUserRepo(): UserRepo {
       return user ? toPublic(user) : null;
     },
 
+    async findManyByIds(ids) {
+      const wanted = new Set(ids.map((id) => Number(id)));
+      return [...users.values()].filter((u) => wanted.has(Number(u.id))).map(toPublic);
+    },
+
     async findByEmail(email) {
       const user = [...users.values()].find((u) => u.email === email);
       return user ? { ...toPublic(user), passwordHash: user.passwordHash } : null;

--- a/src/adapters/prisma.ts
+++ b/src/adapters/prisma.ts
@@ -1,6 +1,7 @@
 import type { Prisma, PrismaClient } from '@prisma/client';
 import type { UserRepo } from '../core/ports/user.repo.js';
 import type { ApiKeyRepo } from '../core/ports/apiKey.repo.js';
+import type { IdempotencyStore } from '../core/ports/idempotency.repo.js';
 import type {
   EmailVerificationTokenRepo,
   OAuthAccountRepo,
@@ -324,6 +325,27 @@ export function makePrismaApiKeyRepo(prisma: PrismaClient): ApiKeyRepo {
       await (prisma as any).apiKey.update({
         where: { id },
         data: { revokedAt: dateOrNow(input.revokedAt) },
+      });
+    },
+  };
+}
+
+/** `IdempotencyStore` implementation; pass it to the `idempotent` middleware to persist replayed responses across instances. */
+export function makePrismaIdempotencyStore(prisma: PrismaClient): IdempotencyStore {
+  return {
+    async get(key) {
+      const record = await (prisma as any).idempotencyKey.findUnique({ where: { key } });
+      if (!record) return null;
+      if (record.expiresAt && record.expiresAt.getTime() <= Date.now()) return null;
+      return { status: record.status, body: record.body };
+    },
+
+    async set(key, record, ttlMs) {
+      const expiresAt = ttlMs !== undefined ? new Date(Date.now() + ttlMs) : null;
+      await (prisma as any).idempotencyKey.upsert({
+        where: { key },
+        create: { key, status: record.status, body: record.body as any, expiresAt },
+        update: { status: record.status, body: record.body as any, expiresAt },
       });
     },
   };

--- a/src/adapters/prisma.ts
+++ b/src/adapters/prisma.ts
@@ -353,7 +353,13 @@ export function makePrismaIdempotencyStore(prisma: PrismaClient): IdempotencySto
     async get(key) {
       const record = await (prisma as any).idempotencyKey.findUnique({ where: { key } });
       if (!record) return null;
-      if (record.expiresAt && record.expiresAt.getTime() <= Date.now()) return null;
+      if (record.expiresAt && record.expiresAt.getTime() <= Date.now()) {
+        // Lazily evict on read, same as the in-memory adapter. This alone doesn't
+        // bound table growth for keys that are set once and never re-read with
+        // the same key — schedule a periodic DELETE WHERE expiresAt < now() too.
+        await (prisma as any).idempotencyKey.delete({ where: { key } }).catch(() => {});
+        return null;
+      }
       return { status: record.status, body: record.body };
     },
 

--- a/src/adapters/prisma.ts
+++ b/src/adapters/prisma.ts
@@ -13,9 +13,10 @@ const dateOrNow = (value?: Date) => value ?? new Date();
 /** `UserRepo` implementation backed by the bundled Prisma schema (`prisma/schema.prisma`). */
 export function makePrismaUserRepo(prisma: PrismaClient): UserRepo {
   return {
-    async count({ role, search }) {
+    async count({ role, search, tenantId }) {
       const where: Prisma.UserWhereInput = {};
       if (role) where.role = role as any;
+      if (tenantId !== undefined) where.tenantId = String(tenantId) as any;
       if (search?.trim()) {
         const s = search.trim();
         where.OR = [
@@ -26,9 +27,10 @@ export function makePrismaUserRepo(prisma: PrismaClient): UserRepo {
       return prisma.user.count({ where });
     },
 
-    async findMany({ page, pageSize, role, search, sortField, sortDir }) {
+    async findMany({ page, pageSize, role, search, tenantId, sortField, sortDir }) {
       const where: Prisma.UserWhereInput = {};
       if (role) where.role = role as any;
+      if (tenantId !== undefined) where.tenantId = String(tenantId) as any;
       if (search?.trim()) {
         const s = search.trim();
         where.OR = [
@@ -47,6 +49,7 @@ export function makePrismaUserRepo(prisma: PrismaClient): UserRepo {
           email: true,
           name: true,
           role: true,
+          tenantId: true,
           createdAt: true,
           updatedAt: true,
           profile: { select: { bio: true, avatarUrl: true } },
@@ -63,6 +66,7 @@ export function makePrismaUserRepo(prisma: PrismaClient): UserRepo {
           email: true,
           name: true,
           role: true,
+          tenantId: true,
           createdAt: true,
           updatedAt: true,
           profile: { select: { bio: true, avatarUrl: true } },
@@ -78,6 +82,7 @@ export function makePrismaUserRepo(prisma: PrismaClient): UserRepo {
           email: true,
           name: true,
           role: true,
+          tenantId: true,
           passwordHash: true,
           createdAt: true,
           updatedAt: true,
@@ -93,10 +98,11 @@ export function makePrismaUserRepo(prisma: PrismaClient): UserRepo {
           passwordHash: input.passwordHash,
           name: input.name ?? null,
           role: (input.role as any) ?? 'USER',
+          tenantId: input.tenantId != null ? String(input.tenantId) : null,
           profile: { create: { bio: input.bio ?? null, avatarUrl: input.avatarUrl ?? null } },
         },
         select: {
-          id: true, email: true, name: true, role: true,
+          id: true, email: true, name: true, role: true, tenantId: true,
           createdAt: true, updatedAt: true,
           profile: { select: { bio: true, avatarUrl: true } },
         },

--- a/src/adapters/prisma.ts
+++ b/src/adapters/prisma.ts
@@ -1,5 +1,6 @@
 import type { Prisma, PrismaClient } from '@prisma/client';
 import type { UserRepo } from '../core/ports/user.repo.js';
+import type { ApiKeyRepo } from '../core/ports/apiKey.repo.js';
 import type {
   EmailVerificationTokenRepo,
   OAuthAccountRepo,
@@ -295,6 +296,34 @@ export function makePrismaOAuthAccountRepo(prisma: PrismaClient): OAuthAccountRe
           userId: input.userId as any,
           email: input.email ?? null,
         },
+      });
+    },
+  };
+}
+
+/** `ApiKeyRepo` implementation; pass it to `isApiKey` to authenticate machine-to-machine requests. */
+export function makePrismaApiKeyRepo(prisma: PrismaClient): ApiKeyRepo {
+  return {
+    findById(id) {
+      return (prisma as any).apiKey.findUnique({ where: { id } });
+    },
+
+    create(input) {
+      return (prisma as any).apiKey.create({
+        data: {
+          id: input.id,
+          name: input.name ?? null,
+          keyHash: input.keyHash,
+          scopes: input.scopes ?? [],
+          tenantId: input.tenantId != null ? String(input.tenantId) : null,
+        },
+      });
+    },
+
+    async revoke(id, input = {}) {
+      await (prisma as any).apiKey.update({
+        where: { id },
+        data: { revokedAt: dateOrNow(input.revokedAt) },
       });
     },
   };

--- a/src/adapters/prisma.ts
+++ b/src/adapters/prisma.ts
@@ -76,6 +76,23 @@ export function makePrismaUserRepo(prisma: PrismaClient): UserRepo {
       }) as any;
     },
 
+    async findManyByIds(ids) {
+      const users = await prisma.user.findMany({
+        where: { id: { in: ids as any } },
+        select: {
+          id: true,
+          email: true,
+          name: true,
+          role: true,
+          tenantId: true,
+          createdAt: true,
+          updatedAt: true,
+          profile: { select: { bio: true, avatarUrl: true } },
+        },
+      });
+      return users as unknown as UserListItem[];
+    },
+
     async findByEmail(email) {
       return prisma.user.findUnique({
         where: { email },

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -12,3 +12,36 @@ export function getJwtSecret(): string {
   }
   return secret;
 }
+
+export type JwtAlgorithm = "HS256" | "RS256";
+
+/** `HS256` (default, shared secret) or `RS256` (asymmetric, for JWKS-based verification across services). */
+export function getJwtAlgorithm(): JwtAlgorithm {
+  return (process.env.JWT_ALG || "HS256").trim().toUpperCase() === "RS256" ? "RS256" : "HS256";
+}
+
+function normalizePemEnv(value: string): string {
+  // Supports keys stored with literal "\n" (common in .env files / CI secrets).
+  return value.includes("\\n") ? value.replace(/\\n/g, "\n") : value;
+}
+
+export function getJwtPrivateKey(): string {
+  const key = process.env.JWT_PRIVATE_KEY?.trim();
+  if (!key) {
+    throw new Error("JWT_PRIVATE_KEY is required when JWT_ALG=RS256");
+  }
+  return normalizePemEnv(key);
+}
+
+export function getJwtPublicKey(): string {
+  const key = process.env.JWT_PUBLIC_KEY?.trim();
+  if (!key) {
+    throw new Error("JWT_PUBLIC_KEY is required when JWT_ALG=RS256");
+  }
+  return normalizePemEnv(key);
+}
+
+/** Key id (`kid`) advertised in JWKS and stamped on RS256 tokens, so multiple keys can rotate side by side. */
+export function getJwtKeyId(): string {
+  return process.env.JWT_KEY_ID?.trim() || "default";
+}

--- a/src/core/ports/apiKey.repo.ts
+++ b/src/core/ports/apiKey.repo.ts
@@ -1,0 +1,25 @@
+export type ApiKeyRecord = {
+  id: string;
+  name?: string | null;
+  keyHash: string;
+  scopes?: string[];
+  tenantId?: string | number | null;
+  revokedAt?: Date | string | null;
+  createdAt?: Date | string;
+};
+
+/**
+ * Storage port for machine-to-machine API keys, used by `isApiKey` to
+ * authenticate service-to-service requests without a user behind them.
+ */
+export interface ApiKeyRepo {
+  findById(id: string): Promise<ApiKeyRecord | null>;
+  create(input: {
+    id: string;
+    name?: string | null;
+    keyHash: string;
+    scopes?: string[];
+    tenantId?: string | number | null;
+  }): Promise<ApiKeyRecord | void>;
+  revoke(id: string, input?: { revokedAt?: Date }): Promise<void>;
+}

--- a/src/core/ports/idempotency.repo.ts
+++ b/src/core/ports/idempotency.repo.ts
@@ -1,0 +1,14 @@
+export type IdempotencyRecord = {
+  status: number;
+  body: unknown;
+};
+
+/**
+ * Storage port for idempotency keys, used by the `idempotent` middleware to
+ * replay a stored response instead of re-running a handler for a repeated
+ * request (retries, concurrent duplicate calls from other services).
+ */
+export interface IdempotencyStore {
+  get(key: string): Promise<IdempotencyRecord | null>;
+  set(key: string, record: IdempotencyRecord, ttlMs?: number): Promise<void>;
+}

--- a/src/core/ports/rateLimiter.repo.ts
+++ b/src/core/ports/rateLimiter.repo.ts
@@ -1,0 +1,15 @@
+export type RateLimitResult = {
+  allowed: boolean;
+  remaining?: number;
+  retryAfterMs?: number;
+};
+
+/**
+ * Rate limiting port. `consume` should be atomic per `key` — implementations
+ * backed by a shared store (Redis, a database) let multiple instances of a
+ * service enforce one limit together.
+ */
+export interface RateLimiter {
+  /** Attempts to spend `cost` (default 1) points for `key`. Returns whether the request is allowed. */
+  consume(key: string, cost?: number): Promise<RateLimitResult>;
+}

--- a/src/core/ports/user.repo.ts
+++ b/src/core/ports/user.repo.ts
@@ -7,20 +7,21 @@ import type { AdminCreateUserInput, AdminUpdateUserInput, ListUsersQuery, UserLi
  */
 export interface UserRepo {
   /** Counts users matching the given filters, for pagination totals. */
-  count(where: { role?: string; search?: string } ): Promise<number>;
+  count(where: { role?: string; search?: string; tenantId?: string | number } ): Promise<number>;
   /** Returns one page of users, sorted per `sortField`/`sortDir`. */
   findMany(params: {
     page: number;
     pageSize: number;
     role?: string;
     search?: string;
+    tenantId?: string | number;
     sortField: 'createdAt'|'updatedAt'|'email'|'name';
     sortDir: 'asc'|'desc';
   }): Promise<UserListItem[]>;
   findById(id: number | string): Promise<UserListItem | null>;
   /** Must include `passwordHash` so the auth service can verify credentials. */
   findByEmail(email: string): Promise<UserListItem & { passwordHash?: string } | null>;
-  create(input: { email: string; passwordHash: string; name?: string | null; role?: string; bio?: string | null; avatarUrl?: string | null }): Promise<UserListItem>;
+  create(input: { email: string; passwordHash: string; name?: string | null; role?: string; bio?: string | null; avatarUrl?: string | null; tenantId?: string | number | null }): Promise<UserListItem>;
   update(id: number | string, input: AdminUpdateUserInput): Promise<UserListItem>;
   delete(id: number | string): Promise<void>;
   /** Self-service update, restricted to the profile fields a user may change on their own account. */

--- a/src/core/ports/user.repo.ts
+++ b/src/core/ports/user.repo.ts
@@ -21,6 +21,12 @@ export interface UserRepo {
   findById(id: number | string): Promise<UserListItem | null>;
   /** Must include `passwordHash` so the auth service can verify credentials. */
   findByEmail(email: string): Promise<UserListItem & { passwordHash?: string } | null>;
+  /**
+   * Resolves multiple users in one call, to avoid N+1/N-parallel lookups
+   * across services. Returns only the users found; unmatched ids are
+   * silently omitted. Optional — falls back to N `findById` calls when absent.
+   */
+  findManyByIds?(ids: Array<number | string>): Promise<UserListItem[]>;
   create(input: { email: string; passwordHash: string; name?: string | null; role?: string; bio?: string | null; avatarUrl?: string | null; tenantId?: string | number | null }): Promise<UserListItem>;
   update(id: number | string, input: AdminUpdateUserInput): Promise<UserListItem>;
   delete(id: number | string): Promise<void>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,7 @@ export {
   adminUpdateUserSchema,
   listUsersQuerySchema,
   updateMeSchema,
+  userIdsBatchSchema,
 } from './modules/user/user.schemas.js';
 export { isAuth, type AuthRequest } from './middleware/isAuth.js';
 export { hasRole, isSelfOrAdmin } from './middleware/hasRole.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ export type {
 } from './modules/user/user.types.js';
 export { createUserRouter } from './modules/user/user.controller.js';
 export { createAuthRouter } from './modules/auth/auth.controller.js';
+export { createJwksRouter } from './modules/jwks/jwks.controller.js';
+export { getJwks, type Jwk } from './utils/jwks.js';
 export { DEFAULT_REGISTER_ROLE, resolveRegisterRole } from './modules/auth/auth.defaults.js';
 export { makeAuthService } from './modules/auth/auth.service.js';
 export {
@@ -85,6 +87,8 @@ import type { UserRepo } from './core/ports/user.repo.js';
 import type { AuthServiceDeps } from './modules/auth/auth.types.js';
 import { createAuthRouter } from './modules/auth/auth.controller.js';
 import { createUserRouter } from './modules/user/user.controller.js';
+import { createJwksRouter } from './modules/jwks/jwks.controller.js';
+import { getJwtAlgorithm } from './config/env.js';
 
 /** Options for `createLibrary`/`mountDefaultRoutes`. */
 export type LibraryConfig = {
@@ -129,6 +133,11 @@ export function createLibrary(config: LibraryConfig, deps: LibraryDeps) {
 
   router.use(`${prefix}/auth`, createAuthRouter({ userRepo: deps.userRepo, ...config.auth }));
   router.use(`${prefix}/users`, createUserRouter({ userRepo: deps.userRepo }));
+
+  // JWKS is a well-known, unprefixed path by convention, and only meaningful with RS256.
+  if (getJwtAlgorithm() === 'RS256') {
+    router.use(createJwksRouter());
+  }
 
   return { router };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import express, { Router, type Express } from 'express';
 import cors from 'cors';
 import bodyParser from 'body-parser';
+import { requestId } from './middleware/requestId.js';
 export type { UserRepo } from './core/ports/user.repo.js';
 export type {
   AdminCreateUserInput,
@@ -63,6 +64,7 @@ export { idempotent } from './middleware/idempotent.js';
 export type { IdempotencyRecord, IdempotencyStore } from './core/ports/idempotency.repo.js';
 export { rateLimit } from './middleware/rateLimit.js';
 export type { RateLimiter, RateLimitResult } from './core/ports/rateLimiter.repo.js';
+export { requestId, type RequestWithId } from './middleware/requestId.js';
 export {
   AppError,
   EmailAlreadyExistsError,
@@ -132,6 +134,7 @@ function normalizePrefix(prefix?: string): string {
 export function createServer(): Express {
   const app = express();
   app.use(cors());
+  app.use(requestId());
   app.use(bodyParser.json());
   return app;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ export {
 } from './modules/user/user.schemas.js';
 export { isAuth, type AuthRequest } from './middleware/isAuth.js';
 export { hasRole, isSelfOrAdmin } from './middleware/hasRole.js';
+export { requireTenant, isSameTenant } from './middleware/tenant.js';
 export {
   AppError,
   EmailAlreadyExistsError,

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,8 @@ export type { ApiKeyRecord, ApiKeyRepo } from './core/ports/apiKey.repo.js';
 export { issueApiKey, verifyApiKey } from './utils/apiKey.js';
 export { idempotent } from './middleware/idempotent.js';
 export type { IdempotencyRecord, IdempotencyStore } from './core/ports/idempotency.repo.js';
+export { rateLimit } from './middleware/rateLimit.js';
+export type { RateLimiter, RateLimitResult } from './core/ports/rateLimiter.repo.js';
 export {
   AppError,
   EmailAlreadyExistsError,
@@ -85,11 +87,17 @@ export {
   makePrismaRefreshTokenRepo,
   makePrismaUserRepo,
 } from './adapters/prisma.js';
-export { makeMemoryApiKeyRepo, makeMemoryIdempotencyStore, makeMemoryUserRepo } from './adapters/memory.js';
+export {
+  makeMemoryApiKeyRepo,
+  makeMemoryIdempotencyStore,
+  makeMemoryRateLimiter,
+  makeMemoryUserRepo,
+} from './adapters/memory.js';
 
 import type { UserRepo } from './core/ports/user.repo.js';
 import type { AuthServiceDeps } from './modules/auth/auth.types.js';
 import type { IdempotencyStore } from './core/ports/idempotency.repo.js';
+import type { RateLimiter } from './core/ports/rateLimiter.repo.js';
 import { createAuthRouter } from './modules/auth/auth.controller.js';
 import { createUserRouter } from './modules/user/user.controller.js';
 import { createJwksRouter } from './modules/jwks/jwks.controller.js';
@@ -108,6 +116,8 @@ export type LibraryDeps = {
   userRepo: UserRepo;
   /** Enables `Idempotency-Key` support on `POST /auth/register` and `POST /users`. */
   idempotencyStore?: IdempotencyStore;
+  /** Enables rate limiting on `POST /auth/login` and `POST /auth/register`. */
+  rateLimiter?: RateLimiter;
 };
 
 function normalizePrefix(prefix?: string): string {
@@ -140,7 +150,12 @@ export function createLibrary(config: LibraryConfig, deps: LibraryDeps) {
 
   router.use(
     `${prefix}/auth`,
-    createAuthRouter({ userRepo: deps.userRepo, idempotencyStore: deps.idempotencyStore, ...config.auth }),
+    createAuthRouter({
+      userRepo: deps.userRepo,
+      idempotencyStore: deps.idempotencyStore,
+      rateLimiter: deps.rateLimiter,
+      ...config.auth,
+    }),
   );
   router.use(`${prefix}/users`, createUserRouter({ userRepo: deps.userRepo, idempotencyStore: deps.idempotencyStore }));
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,8 @@ export { requireTenant, isSameTenant } from './middleware/tenant.js';
 export { isApiKey, type ApiKeyRequest } from './middleware/isApiKey.js';
 export type { ApiKeyRecord, ApiKeyRepo } from './core/ports/apiKey.repo.js';
 export { issueApiKey, verifyApiKey } from './utils/apiKey.js';
+export { idempotent } from './middleware/idempotent.js';
+export type { IdempotencyRecord, IdempotencyStore } from './core/ports/idempotency.repo.js';
 export {
   AppError,
   EmailAlreadyExistsError,
@@ -76,15 +78,17 @@ export {
 export {
   makePrismaApiKeyRepo,
   makePrismaEmailVerificationTokenRepo,
+  makePrismaIdempotencyStore,
   makePrismaOAuthAccountRepo,
   makePrismaPasswordResetTokenRepo,
   makePrismaRefreshTokenRepo,
   makePrismaUserRepo,
 } from './adapters/prisma.js';
-export { makeMemoryApiKeyRepo, makeMemoryUserRepo } from './adapters/memory.js';
+export { makeMemoryApiKeyRepo, makeMemoryIdempotencyStore, makeMemoryUserRepo } from './adapters/memory.js';
 
 import type { UserRepo } from './core/ports/user.repo.js';
 import type { AuthServiceDeps } from './modules/auth/auth.types.js';
+import type { IdempotencyStore } from './core/ports/idempotency.repo.js';
 import { createAuthRouter } from './modules/auth/auth.controller.js';
 import { createUserRouter } from './modules/user/user.controller.js';
 import { createJwksRouter } from './modules/jwks/jwks.controller.js';
@@ -101,6 +105,8 @@ export type LibraryConfig = {
 /** Dependencies for `createLibrary`/`mountDefaultRoutes`. */
 export type LibraryDeps = {
   userRepo: UserRepo;
+  /** Enables `Idempotency-Key` support on `POST /auth/register` and `POST /users`. */
+  idempotencyStore?: IdempotencyStore;
 };
 
 function normalizePrefix(prefix?: string): string {
@@ -131,8 +137,11 @@ export function createLibrary(config: LibraryConfig, deps: LibraryDeps) {
   const router = Router();
   const prefix = normalizePrefix(config.routesPrefix);
 
-  router.use(`${prefix}/auth`, createAuthRouter({ userRepo: deps.userRepo, ...config.auth }));
-  router.use(`${prefix}/users`, createUserRouter({ userRepo: deps.userRepo }));
+  router.use(
+    `${prefix}/auth`,
+    createAuthRouter({ userRepo: deps.userRepo, idempotencyStore: deps.idempotencyStore, ...config.auth }),
+  );
+  router.use(`${prefix}/users`, createUserRouter({ userRepo: deps.userRepo, idempotencyStore: deps.idempotencyStore }));
 
   // JWKS is a well-known, unprefixed path by convention, and only meaningful with RS256.
   if (getJwtAlgorithm() === 'RS256') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,9 @@ export {
 export { isAuth, type AuthRequest } from './middleware/isAuth.js';
 export { hasRole, isSelfOrAdmin } from './middleware/hasRole.js';
 export { requireTenant, isSameTenant } from './middleware/tenant.js';
+export { isApiKey, type ApiKeyRequest } from './middleware/isApiKey.js';
+export type { ApiKeyRecord, ApiKeyRepo } from './core/ports/apiKey.repo.js';
+export { issueApiKey, verifyApiKey } from './utils/apiKey.js';
 export {
   AppError,
   EmailAlreadyExistsError,
@@ -69,13 +72,14 @@ export {
   type FieldValidationIssue,
 } from './utils/errorHandler.js';
 export {
+  makePrismaApiKeyRepo,
   makePrismaEmailVerificationTokenRepo,
   makePrismaOAuthAccountRepo,
   makePrismaPasswordResetTokenRepo,
   makePrismaRefreshTokenRepo,
   makePrismaUserRepo,
 } from './adapters/prisma.js';
-export { makeMemoryUserRepo } from './adapters/memory.js';
+export { makeMemoryApiKeyRepo, makeMemoryUserRepo } from './adapters/memory.js';
 
 import type { UserRepo } from './core/ports/user.repo.js';
 import type { AuthServiceDeps } from './modules/auth/auth.types.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export type {
 export { createUserRouter } from './modules/user/user.controller.js';
 export { createAuthRouter } from './modules/auth/auth.controller.js';
 export { createJwksRouter } from './modules/jwks/jwks.controller.js';
+export { createHealthRouter } from './modules/health/health.controller.js';
 export { getJwks, type Jwk } from './utils/jwks.js';
 export { DEFAULT_REGISTER_ROLE, resolveRegisterRole } from './modules/auth/auth.defaults.js';
 export { makeAuthService } from './modules/auth/auth.service.js';
@@ -103,6 +104,7 @@ import type { RateLimiter } from './core/ports/rateLimiter.repo.js';
 import { createAuthRouter } from './modules/auth/auth.controller.js';
 import { createUserRouter } from './modules/user/user.controller.js';
 import { createJwksRouter } from './modules/jwks/jwks.controller.js';
+import { createHealthRouter } from './modules/health/health.controller.js';
 import { getJwtAlgorithm } from './config/env.js';
 
 /** Options for `createLibrary`/`mountDefaultRoutes`. */
@@ -111,6 +113,8 @@ export type LibraryConfig = {
   routesPrefix?: string;
   /** Passed through to `createAuthRouter` alongside `deps.userRepo`. */
   auth?: Omit<AuthServiceDeps, 'userRepo'>;
+  /** Mounts `GET /health` and `GET /ready` (unprefixed). Defaults to `true`. */
+  health?: boolean;
 };
 
 /** Dependencies for `createLibrary`/`mountDefaultRoutes`. */
@@ -165,6 +169,11 @@ export function createLibrary(config: LibraryConfig, deps: LibraryDeps) {
   // JWKS is a well-known, unprefixed path by convention, and only meaningful with RS256.
   if (getJwtAlgorithm() === 'RS256') {
     router.use(createJwksRouter());
+  }
+
+  // /health and /ready are unprefixed by convention, for orchestrator probes.
+  if (config.health !== false) {
+    router.use(createHealthRouter({ userRepo: deps.userRepo }));
   }
 
   return { router };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,3 +3,4 @@ export { isAuth, type AuthRequest } from './middleware/isAuth.js';
 export { requireTenant, isSameTenant } from './middleware/tenant.js';
 export { isApiKey, type ApiKeyRequest } from './middleware/isApiKey.js';
 export { idempotent } from './middleware/idempotent.js';
+export { rateLimit } from './middleware/rateLimit.js';

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,3 +4,4 @@ export { requireTenant, isSameTenant } from './middleware/tenant.js';
 export { isApiKey, type ApiKeyRequest } from './middleware/isApiKey.js';
 export { idempotent } from './middleware/idempotent.js';
 export { rateLimit } from './middleware/rateLimit.js';
+export { requestId, type RequestWithId } from './middleware/requestId.js';

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,2 +1,3 @@
 export { hasRole, isSelfOrAdmin } from './middleware/hasRole.js';
 export { isAuth, type AuthRequest } from './middleware/isAuth.js';
+export { requireTenant, isSameTenant } from './middleware/tenant.js';

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,3 +1,4 @@
 export { hasRole, isSelfOrAdmin } from './middleware/hasRole.js';
 export { isAuth, type AuthRequest } from './middleware/isAuth.js';
 export { requireTenant, isSameTenant } from './middleware/tenant.js';
+export { isApiKey, type ApiKeyRequest } from './middleware/isApiKey.js';

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,3 +2,4 @@ export { hasRole, isSelfOrAdmin } from './middleware/hasRole.js';
 export { isAuth, type AuthRequest } from './middleware/isAuth.js';
 export { requireTenant, isSameTenant } from './middleware/tenant.js';
 export { isApiKey, type ApiKeyRequest } from './middleware/isApiKey.js';
+export { idempotent } from './middleware/idempotent.js';

--- a/src/middleware/idempotent.ts
+++ b/src/middleware/idempotent.ts
@@ -1,0 +1,35 @@
+import type { Request, Response, NextFunction } from 'express';
+import type { IdempotencyStore } from '../core/ports/idempotency.repo.js';
+
+/**
+ * Replays a stored response for repeated requests carrying the same
+ * `Idempotency-Key` header, instead of re-running the handler. Requests
+ * without the header pass through unaffected — idempotency is opt-in per
+ * call, not enforced on every request.
+ */
+export function idempotent(store: IdempotencyStore, options?: { headerName?: string; ttlMs?: number }) {
+  const headerName = (options?.headerName ?? 'idempotency-key').toLowerCase();
+  const ttlMs = options?.ttlMs;
+
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const raw = req.headers[headerName];
+    const key = Array.isArray(raw) ? raw[0] : raw;
+    if (!key) return next();
+
+    const existing = await store.get(key);
+    if (existing) {
+      res.setHeader('Idempotent-Replay', 'true');
+      return res.status(existing.status).json(existing.body);
+    }
+
+    const originalJson = res.json.bind(res);
+    res.json = ((body: unknown) => {
+      store.set(key, { status: res.statusCode, body }, ttlMs).catch((err) => {
+        console.error('[my-crud-lib] failed to persist idempotency record:', err);
+      });
+      return originalJson(body);
+    }) as Response['json'];
+
+    return next();
+  };
+}

--- a/src/middleware/idempotent.ts
+++ b/src/middleware/idempotent.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, NextFunction } from 'express';
 import type { IdempotencyStore } from '../core/ports/idempotency.repo.js';
+import { sendAppError } from '../utils/errorHandler.js';
 
 /**
  * Replays a stored response for repeated requests carrying the same
@@ -16,7 +17,13 @@ export function idempotent(store: IdempotencyStore, options?: { headerName?: str
     const key = Array.isArray(raw) ? raw[0] : raw;
     if (!key) return next();
 
-    const existing = await store.get(key);
+    let existing;
+    try {
+      existing = await store.get(key);
+    } catch (err) {
+      return sendAppError(res, err);
+    }
+
     if (existing) {
       res.setHeader('Idempotent-Replay', 'true');
       return res.status(existing.status).json(existing.body);

--- a/src/middleware/isApiKey.ts
+++ b/src/middleware/isApiKey.ts
@@ -1,6 +1,7 @@
 import type { Request, Response, NextFunction } from 'express';
 import type { ApiKeyRepo } from '../core/ports/apiKey.repo.js';
 import { verifyApiKey } from '../utils/apiKey.js';
+import { sendAppError } from '../utils/errorHandler.js';
 
 export type ApiKeyRequest = Request & {
   apiKey?: { id: string; name?: string | null; scopes: string[]; tenantId?: string | number };
@@ -29,7 +30,13 @@ export function isApiKey(apiKeyRepo: ApiKeyRepo, options?: { requiredScopes?: st
     }
 
     const [id] = key.split('.');
-    const record = id ? await apiKeyRepo.findById(id) : null;
+    let record;
+    try {
+      record = id ? await apiKeyRepo.findById(id) : null;
+    } catch (err) {
+      return sendAppError(res, err);
+    }
+
     if (!record || record.revokedAt || !verifyApiKey(key, record)) {
       return res.status(401).json({ error: { code: 'UNAUTHORIZED', message: 'Invalid or revoked API key' } });
     }

--- a/src/middleware/isApiKey.ts
+++ b/src/middleware/isApiKey.ts
@@ -1,0 +1,45 @@
+import type { Request, Response, NextFunction } from 'express';
+import type { ApiKeyRepo } from '../core/ports/apiKey.repo.js';
+import { verifyApiKey } from '../utils/apiKey.js';
+
+export type ApiKeyRequest = Request & {
+  apiKey?: { id: string; name?: string | null; scopes: string[]; tenantId?: string | number };
+};
+
+function extractKey(req: Request): string | null {
+  const headerKey = req.headers['x-api-key'];
+  if (typeof headerKey === 'string' && headerKey) return headerKey;
+
+  const auth = req.headers.authorization;
+  if (auth?.startsWith('ApiKey ')) return auth.slice('ApiKey '.length);
+
+  return null;
+}
+
+/**
+ * Authenticates machine-to-machine requests via an API key, read from the
+ * `X-API-Key` header or `Authorization: ApiKey <key>`. Attaches `req.apiKey`
+ * on success. Pass `requiredScopes` to also enforce scope membership.
+ */
+export function isApiKey(apiKeyRepo: ApiKeyRepo, options?: { requiredScopes?: string[] }) {
+  return async (req: ApiKeyRequest, res: Response, next: NextFunction) => {
+    const key = extractKey(req);
+    if (!key) {
+      return res.status(401).json({ error: { code: 'UNAUTHORIZED', message: 'Missing API key' } });
+    }
+
+    const [id] = key.split('.');
+    const record = id ? await apiKeyRepo.findById(id) : null;
+    if (!record || record.revokedAt || !verifyApiKey(key, record)) {
+      return res.status(401).json({ error: { code: 'UNAUTHORIZED', message: 'Invalid or revoked API key' } });
+    }
+
+    const scopes = record.scopes ?? [];
+    if (options?.requiredScopes?.length && options.requiredScopes.some((scope) => !scopes.includes(scope))) {
+      return res.status(403).json({ error: { code: 'FORBIDDEN', message: 'Missing required API key scope' } });
+    }
+
+    req.apiKey = { id: record.id, name: record.name, scopes, tenantId: record.tenantId ?? undefined };
+    return next();
+  };
+}

--- a/src/middleware/isAuth.ts
+++ b/src/middleware/isAuth.ts
@@ -1,7 +1,9 @@
 import type { Request, Response, NextFunction } from 'express';
 import { verifyToken } from '../utils/jwt.js';
 
-export type AuthRequest = Request & { user?: { id: number | string; role: 'USER' | 'ADMIN' } };
+export type AuthRequest = Request & {
+  user?: { id: number | string; role: 'USER' | 'ADMIN'; tenantId?: string | number };
+};
 
 /** Verifies the `Authorization: Bearer <token>` header and attaches `req.user`. Responds 401 if missing/invalid. */
 export function isAuth(req: AuthRequest, res: Response, next: NextFunction) {
@@ -11,8 +13,8 @@ export function isAuth(req: AuthRequest, res: Response, next: NextFunction) {
   }
   const token = auth.substring('Bearer '.length);
   try {
-    const payload = verifyToken<{ sub: number | string; role: 'USER' | 'ADMIN' }>(token);
-    req.user = { id: payload.sub, role: payload.role };
+    const payload = verifyToken<{ sub: number | string; role: 'USER' | 'ADMIN'; tenantId?: string | number }>(token);
+    req.user = { id: payload.sub, role: payload.role, ...(payload.tenantId !== undefined ? { tenantId: payload.tenantId } : {}) };
     return next();
   } catch {
     return res.status(401).json({ error: 'Invalid or expired token' });

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -1,0 +1,22 @@
+import type { Request, Response, NextFunction } from 'express';
+import type { RateLimiter } from '../core/ports/rateLimiter.repo.js';
+
+function defaultKey(req: Request): string {
+  return req.ip ?? 'unknown';
+}
+
+/** Enforces a `RateLimiter` on a route, keyed by `keyFn` (defaults to `req.ip`). Responds `429` with `Retry-After` when exceeded. */
+export function rateLimit(limiter: RateLimiter, options?: { keyFn?: (req: Request) => string; cost?: number }) {
+  const keyFn = options?.keyFn ?? defaultKey;
+
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const result = await limiter.consume(keyFn(req), options?.cost);
+    if (!result.allowed) {
+      if (result.retryAfterMs !== undefined) {
+        res.setHeader('Retry-After', Math.ceil(result.retryAfterMs / 1000).toString());
+      }
+      return res.status(429).json({ error: { code: 'RATE_LIMITED', message: 'Too many requests' } });
+    }
+    return next();
+  };
+}

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, NextFunction } from 'express';
 import type { RateLimiter } from '../core/ports/rateLimiter.repo.js';
+import { sendAppError } from '../utils/errorHandler.js';
 
 function defaultKey(req: Request): string {
   return req.ip ?? 'unknown';
@@ -10,7 +11,13 @@ export function rateLimit(limiter: RateLimiter, options?: { keyFn?: (req: Reques
   const keyFn = options?.keyFn ?? defaultKey;
 
   return async (req: Request, res: Response, next: NextFunction) => {
-    const result = await limiter.consume(keyFn(req), options?.cost);
+    let result;
+    try {
+      result = await limiter.consume(keyFn(req), options?.cost);
+    } catch (err) {
+      return sendAppError(res, err);
+    }
+
     if (!result.allowed) {
       if (result.retryAfterMs !== undefined) {
         res.setHeader('Retry-After', Math.ceil(result.retryAfterMs / 1000).toString());

--- a/src/middleware/requestId.ts
+++ b/src/middleware/requestId.ts
@@ -1,0 +1,22 @@
+import { randomUUID } from 'node:crypto';
+import type { Request, Response, NextFunction } from 'express';
+
+export type RequestWithId = Request & { id: string };
+
+/**
+ * Reads a correlation id from the request (default `X-Request-Id`), or
+ * generates one, attaches it as `req.id`, and reflects it back in the
+ * response header — so a request can be traced across services that all
+ * mount this middleware (gateway -> this service -> downstream calls).
+ */
+export function requestId(options?: { headerName?: string }) {
+  const headerName = (options?.headerName ?? 'x-request-id').toLowerCase();
+
+  return (req: Request, res: Response, next: NextFunction) => {
+    const incoming = req.headers[headerName];
+    const id = (Array.isArray(incoming) ? incoming[0] : incoming) || randomUUID();
+    (req as RequestWithId).id = id;
+    res.setHeader('X-Request-Id', id);
+    next();
+  };
+}

--- a/src/middleware/tenant.ts
+++ b/src/middleware/tenant.ts
@@ -1,0 +1,30 @@
+import type { Response, NextFunction } from 'express';
+import type { AuthRequest } from './isAuth.js';
+
+/** Requires `req.user.tenantId` to be set (rejects tokens issued for a single-tenant/no-tenant context). Responds 403 otherwise. */
+export function requireTenant() {
+  return (req: AuthRequest, res: Response, next: NextFunction) => {
+    if (req.user?.tenantId === undefined) {
+      return res.status(403).json({ error: { code: 'FORBIDDEN', message: 'Forbidden: no tenant on this token' } });
+    }
+    next();
+  };
+}
+
+/**
+ * Compares `req.user.tenantId` against a tenant id resolved from the request
+ * (by default `req.params.tenantId`). Responds 403 on mismatch, or when
+ * either side is missing. Pass a custom `getResourceTenantId` to resolve the
+ * tenant id from elsewhere (e.g. a loaded resource) instead of a route param.
+ */
+export function isSameTenant(getResourceTenantId?: (req: AuthRequest) => string | number | undefined) {
+  const resolve = getResourceTenantId ?? ((req: AuthRequest) => req.params.tenantId);
+  return (req: AuthRequest, res: Response, next: NextFunction) => {
+    const userTenantId = req.user?.tenantId;
+    const resourceTenantId = resolve(req);
+    if (userTenantId === undefined || resourceTenantId === undefined || String(userTenantId) !== String(resourceTenantId)) {
+      return res.status(403).json({ error: { code: 'FORBIDDEN', message: 'Forbidden: tenant mismatch' } });
+    }
+    next();
+  };
+}

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,6 +1,8 @@
 import { Router, type Request, type Response } from 'express';
 import { isAuth, type AuthRequest } from '../../middleware/isAuth.js';
+import { idempotent } from '../../middleware/idempotent.js';
 import { sendAppError } from '../../utils/errorHandler.js';
+import type { IdempotencyStore } from '../../core/ports/idempotency.repo.js';
 import {
   emailVerificationConfirmSchema,
   emailVerificationRequestSchema,
@@ -12,17 +14,23 @@ import {
 import { makeAuthService } from './auth.service.js';
 import type { AuthServiceDeps } from './auth.types.js';
 
+export type AuthRouterDeps = AuthServiceDeps & {
+  /** Enables `Idempotency-Key` support on `POST /register` when provided. */
+  idempotencyStore?: IdempotencyStore;
+};
+
 /**
  * Builds the auth router: register, login, refresh, logout, password reset,
  * email verification, and `GET /me`. Password reset, email verification, and
  * OAuth linking are only active when their corresponding repo/callback deps
  * are provided; otherwise those routes respond with `NotConfiguredError`.
  */
-export function createAuthRouter(deps: AuthServiceDeps) {
+export function createAuthRouter(deps: AuthRouterDeps) {
   const router = Router();
   const service = makeAuthService(deps);
+  const registerMiddleware = deps.idempotencyStore ? [idempotent(deps.idempotencyStore)] : [];
 
-  router.post('/register', async (req: Request, res: Response) => {
+  router.post('/register', ...registerMiddleware, async (req: Request, res: Response) => {
     try {
       const data = registerSchema.parse(req.body);
       const result = await service.registerUser(data);

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,8 +1,10 @@
 import { Router, type Request, type Response } from 'express';
 import { isAuth, type AuthRequest } from '../../middleware/isAuth.js';
 import { idempotent } from '../../middleware/idempotent.js';
+import { rateLimit } from '../../middleware/rateLimit.js';
 import { sendAppError } from '../../utils/errorHandler.js';
 import type { IdempotencyStore } from '../../core/ports/idempotency.repo.js';
+import type { RateLimiter } from '../../core/ports/rateLimiter.repo.js';
 import {
   emailVerificationConfirmSchema,
   emailVerificationRequestSchema,
@@ -17,6 +19,8 @@ import type { AuthServiceDeps } from './auth.types.js';
 export type AuthRouterDeps = AuthServiceDeps & {
   /** Enables `Idempotency-Key` support on `POST /register` when provided. */
   idempotencyStore?: IdempotencyStore;
+  /** Enables rate limiting on `POST /login` and `POST /register` when provided, keyed by IP + route. */
+  rateLimiter?: RateLimiter;
 };
 
 /**
@@ -28,7 +32,14 @@ export type AuthRouterDeps = AuthServiceDeps & {
 export function createAuthRouter(deps: AuthRouterDeps) {
   const router = Router();
   const service = makeAuthService(deps);
-  const registerMiddleware = deps.idempotencyStore ? [idempotent(deps.idempotencyStore)] : [];
+
+  const registerMiddleware = [
+    ...(deps.rateLimiter ? [rateLimit(deps.rateLimiter, { keyFn: (req) => `register:${req.ip}` })] : []),
+    ...(deps.idempotencyStore ? [idempotent(deps.idempotencyStore)] : []),
+  ];
+  const loginMiddleware = deps.rateLimiter
+    ? [rateLimit(deps.rateLimiter, { keyFn: (req) => `login:${req.ip}` })]
+    : [];
 
   router.post('/register', ...registerMiddleware, async (req: Request, res: Response) => {
     try {
@@ -40,7 +51,7 @@ export function createAuthRouter(deps: AuthRouterDeps) {
     }
   });
 
-  router.post('/login', async (req: Request, res: Response) => {
+  router.post('/login', ...loginMiddleware, async (req: Request, res: Response) => {
     try {
       const data = loginSchema.parse(req.body);
       const result = await service.loginUser(data);

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -44,7 +44,10 @@ export function createAuthRouter(deps: AuthRouterDeps) {
   router.post('/register', ...registerMiddleware, async (req: Request, res: Response) => {
     try {
       const data = registerSchema.parse(req.body);
-      const result = await service.registerUser(data);
+      // Self-registration is unauthenticated: only honor a client-supplied tenantId
+      // when the app has explicitly opted in, otherwise anyone could join any tenant.
+      const tenantId = deps.allowTenantIdOnRegister ? data.tenantId : undefined;
+      const result = await service.registerUser({ ...data, tenantId });
       return res.status(201).json(result);
     } catch (err) {
       return sendAppError(res, err);

--- a/src/modules/auth/auth.schemas.ts
+++ b/src/modules/auth/auth.schemas.ts
@@ -4,6 +4,7 @@ export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
   name: z.string().min(1).max(100).nullish(),
+  tenantId: z.union([z.string(), z.number()]).nullish(),
 });
 
 export const loginSchema = z.object({

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -84,11 +84,11 @@ function safeEqual(a: string, b: string): boolean {
 }
 
 async function issueTokens(
-  user: Pick<AuthUser, 'id' | 'role'>,
+  user: Pick<AuthUser, 'id' | 'role' | 'tenantId'>,
   deps: AuthServiceDeps,
   familyId?: string,
 ): Promise<AuthTokens & { refreshTokenId?: string; familyId?: string }> {
-  const payload = { sub: user.id, role: user.role };
+  const payload = { sub: user.id, role: user.role, ...(user.tenantId != null ? { tenantId: user.tenantId } : {}) };
   const accessToken = signAccessToken(payload);
 
   if (!deps.refreshTokenRepo) {
@@ -285,6 +285,7 @@ export function makeAuthService(deps: AuthServiceDeps) {
         passwordHash,
         name: params.name ?? null,
         role,
+        tenantId: params.tenantId ?? null,
       });
 
       const authUser = toAuthUser(user);

--- a/src/modules/auth/auth.types.ts
+++ b/src/modules/auth/auth.types.ts
@@ -122,6 +122,15 @@ export type AuthServiceDeps = {
   onLoginSuccess?: (user: AuthUser) => Promise<void> | void;
   /** Called after a password reset is confirmed and the new password is saved. Errors are not thrown to the caller. */
   onPasswordReset?: (user: AuthUser) => Promise<void> | void;
+  /**
+   * Allows an anonymous caller of `POST /register` to set their own `tenantId`.
+   * Defaults to `false`: self-registration is unauthenticated, so accepting a
+   * client-supplied tenant id would let anyone join any tenant by guessing or
+   * copying its id. Leave this off and assign `tenantId` server-side instead
+   * (e.g. from a verified invite token) unless you have your own way to
+   * authorize which tenant a new registrant may join.
+   */
+  allowTenantIdOnRegister?: boolean;
 };
 
 export type AuthUser = UserListItem;

--- a/src/modules/health/health.controller.ts
+++ b/src/modules/health/health.controller.ts
@@ -1,0 +1,29 @@
+import { Router } from 'express';
+import type { UserRepo } from '../../core/ports/user.repo.js';
+
+/**
+ * Exposes `GET /health` (liveness — always 200, no dependencies) and
+ * `GET /ready` (readiness — 200 only if `userRepo` responds, 503 otherwise).
+ * Intended for orchestrator probes (Kubernetes, ECS, etc.).
+ */
+export function createHealthRouter(deps: { userRepo: UserRepo }) {
+  const router = Router();
+
+  router.get('/health', (_req, res) => {
+    res.status(200).json({ status: 'ok' });
+  });
+
+  router.get('/ready', async (_req, res) => {
+    try {
+      await deps.userRepo.count({});
+      res.status(200).json({ status: 'ok' });
+    } catch (err) {
+      res.status(503).json({
+        status: 'error',
+        error: err instanceof Error ? err.message : 'Readiness check failed',
+      });
+    }
+  });
+
+  return router;
+}

--- a/src/modules/jwks/jwks.controller.ts
+++ b/src/modules/jwks/jwks.controller.ts
@@ -1,0 +1,13 @@
+import { Router } from 'express';
+import { getJwks } from '../../utils/jwks.js';
+
+/** Exposes `GET /.well-known/jwks.json` so other services can verify RS256 tokens without sharing a secret. */
+export function createJwksRouter() {
+  const router = Router();
+
+  router.get('/.well-known/jwks.json', (_req, res) => {
+    res.json(getJwks());
+  });
+
+  return router;
+}

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -20,10 +20,12 @@ export function createUserRouter(deps: { userRepo: UserRepo }) {
   const router = Router();
   const service = makeUserService({ userRepo: deps.userRepo });
 
-  router.get('/', isAuth, hasRole('ADMIN'), async (req, res) => {
+  router.get('/', isAuth, hasRole('ADMIN'), async (req: AuthRequest, res) => {
     try {
       const q = listUsersQuerySchema.parse(req.query);
-      const data = await service.listUsers(q);
+      // An admin scoped to a tenant can only ever list users within that tenant.
+      const scopedQuery = req.user!.tenantId !== undefined ? { ...q, tenantId: req.user!.tenantId } : q;
+      const data = await service.listUsers(scopedQuery);
       res.json(data);
     } catch (err) {
       sendAppError(res, err);
@@ -60,7 +62,7 @@ export function createUserRouter(deps: { userRepo: UserRepo }) {
     const id = Number(req.params.id);
     if (Number.isNaN(id)) return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'Invalid id' } });
 
-    const data = await service.getUserById(id);
+    const data = await service.getUserById(id, req.user!.tenantId);
     if (!data) return sendAppError(res, new Error('USER_NOT_FOUND'));
     res.json(data);
   });
@@ -69,6 +71,9 @@ export function createUserRouter(deps: { userRepo: UserRepo }) {
     try {
       const id = Number(req.params.id);
       if (Number.isNaN(id)) return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'Invalid id' } });
+
+      const existing = await service.getUserById(id, req.user!.tenantId);
+      if (!existing) return sendAppError(res, new Error('USER_NOT_FOUND'));
 
       const body = adminUpdateUserSchema.parse(req.body);
 
@@ -84,10 +89,13 @@ export function createUserRouter(deps: { userRepo: UserRepo }) {
     }
   });
 
-  router.delete('/:id', isAuth, hasRole('ADMIN'), async (req, res) => {
+  router.delete('/:id', isAuth, hasRole('ADMIN'), async (req: AuthRequest, res) => {
     try {
       const id = Number(req.params.id);
       if (Number.isNaN(id)) return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'Invalid id' } });
+
+      const existing = await service.getUserById(id, req.user!.tenantId);
+      if (!existing) return sendAppError(res, new Error('USER_NOT_FOUND'));
 
       await service.adminDeleteUser(id);
       res.status(204).end();

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -8,6 +8,7 @@ import {
   updateMeSchema,
   adminCreateUserSchema,
   adminUpdateUserSchema,
+  userIdsBatchSchema,
 } from './user.schemas.js';
 import { makeUserService } from './user.service.js';
 import type { UserRepo } from '../../core/ports/user.repo.js';
@@ -62,6 +63,16 @@ export function createUserRouter(deps: UserRouterDeps) {
       const body = adminCreateUserSchema.parse(req.body);
       const data = await service.adminCreateUser(body);
       res.status(201).json(data);
+    } catch (err) {
+      sendAppError(res, err);
+    }
+  });
+
+  router.post('/batch', isAuth, hasRole('ADMIN'), async (req: AuthRequest, res) => {
+    try {
+      const { ids } = userIdsBatchSchema.parse(req.body);
+      const data = await service.getUsersByIds(ids, req.user!.tenantId);
+      res.json({ items: data });
     } catch (err) {
       sendAppError(res, err);
     }

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { isAuth, type AuthRequest } from '../../middleware/isAuth.js';
 import { hasRole, isSelfOrAdmin } from '../../middleware/hasRole.js';
+import { idempotent } from '../../middleware/idempotent.js';
 import { ForbiddenError, sendAppError } from '../../utils/errorHandler.js';
 import {
   listUsersQuerySchema,
@@ -10,15 +11,23 @@ import {
 } from './user.schemas.js';
 import { makeUserService } from './user.service.js';
 import type { UserRepo } from '../../core/ports/user.repo.js';
+import type { IdempotencyStore } from '../../core/ports/idempotency.repo.js';
+
+export type UserRouterDeps = {
+  userRepo: UserRepo;
+  /** Enables `Idempotency-Key` support on `POST /` (admin create) when provided. */
+  idempotencyStore?: IdempotencyStore;
+};
 
 /**
  * Builds the user CRUD router: admin list/create/update/delete plus
  * `GET/PUT /me` for the authenticated user. Admin routes require an
  * `ADMIN` bearer token; `/:id` routes allow the resource owner or an admin.
  */
-export function createUserRouter(deps: { userRepo: UserRepo }) {
+export function createUserRouter(deps: UserRouterDeps) {
   const router = Router();
   const service = makeUserService({ userRepo: deps.userRepo });
+  const createMiddleware = deps.idempotencyStore ? [idempotent(deps.idempotencyStore)] : [];
 
   router.get('/', isAuth, hasRole('ADMIN'), async (req: AuthRequest, res) => {
     try {
@@ -48,7 +57,7 @@ export function createUserRouter(deps: { userRepo: UserRepo }) {
     }
   });
 
-  router.post('/', isAuth, hasRole('ADMIN'), async (req, res) => {
+  router.post('/', isAuth, hasRole('ADMIN'), ...createMiddleware, async (req, res) => {
     try {
       const body = adminCreateUserSchema.parse(req.body);
       const data = await service.adminCreateUser(body);

--- a/src/modules/user/user.schemas.ts
+++ b/src/modules/user/user.schemas.ts
@@ -20,6 +20,7 @@ export const listUsersQuerySchema = z.object({
     .transform((v) => (v === '' ? undefined : v))
     .optional(),
   role: z.enum(['USER', 'ADMIN']).optional(),
+  tenantId: z.union([z.string(), z.coerce.number()]).optional(),
   sort: SortEnum.default('createdAt:desc'),
 });
 
@@ -36,6 +37,7 @@ export const adminCreateUserSchema = z.object({
   role: z.enum(['USER', 'ADMIN']).default('USER'),
   bio: z.string().max(500).nullish(),
   avatarUrl: z.string().url().nullish(),
+  tenantId: z.union([z.string(), z.number()]).nullish(),
 });
 
 export const adminUpdateUserSchema = z.object({

--- a/src/modules/user/user.schemas.ts
+++ b/src/modules/user/user.schemas.ts
@@ -47,7 +47,12 @@ export const adminUpdateUserSchema = z.object({
   avatarUrl: z.string().url().nullish(),
 });
 
+export const userIdsBatchSchema = z.object({
+  ids: z.array(z.union([z.string(), z.number()])).min(1).max(100),
+});
+
 export type ListUsersQuery = z.infer<typeof listUsersQuerySchema>;
+export type UserIdsBatchInput = z.infer<typeof userIdsBatchSchema>;
 export type UpdateMeInput = z.infer<typeof updateMeSchema>;
 export type AdminCreateUserInput = z.infer<typeof adminCreateUserSchema>;
 export type AdminUpdateUserInput = z.infer<typeof adminUpdateUserSchema>;

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -25,17 +25,20 @@ export function makeUserService(deps: { userRepo: UserRepo }) {
 
   return {
     async listUsers(q: ListUsersQuery): Promise<Paginated<UserListItem>> {
-      const { page, pageSize, role, search } = q;
+      const { page, pageSize, role, search, tenantId } = q;
       const { sortField, sortDir } = parseSort(q.sort);
       const [total, items] = await Promise.all([
-        userRepo.count({ role, search }),
-        userRepo.findMany({ page, pageSize, role, search, sortField, sortDir }),
+        userRepo.count({ role, search, tenantId }),
+        userRepo.findMany({ page, pageSize, role, search, tenantId, sortField, sortDir }),
       ]);
       return { page, pageSize, total, totalPages: Math.ceil(total / pageSize), items };
     },
 
-    getUserById(id: number | string) {
-      return userRepo.findById(id);
+    async getUserById(id: number | string, tenantId?: string | number) {
+      const user = await userRepo.findById(id);
+      if (!user) return null;
+      if (tenantId !== undefined && String(user.tenantId ?? '') !== String(tenantId)) return null;
+      return user;
     },
 
     updateMe(userId: number | string, data: UpdateMeInput) {
@@ -54,6 +57,7 @@ export function makeUserService(deps: { userRepo: UserRepo }) {
         role: input.role ?? 'USER',
         bio: input.bio ?? null,
         avatarUrl: input.avatarUrl ?? null,
+        tenantId: input.tenantId ?? null,
       });
     },
 

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -41,6 +41,17 @@ export function makeUserService(deps: { userRepo: UserRepo }) {
       return user;
     },
 
+    /** Resolves multiple users in one call. Uses `UserRepo.findManyByIds` when the adapter supports it, otherwise falls back to N `findById` calls. */
+    async getUsersByIds(ids: Array<number | string>, tenantId?: string | number): Promise<UserListItem[]> {
+      const users = userRepo.findManyByIds
+        ? await userRepo.findManyByIds(ids)
+        : (await Promise.all(ids.map((id) => userRepo.findById(id)))).filter((u): u is UserListItem => u !== null);
+
+      return tenantId === undefined
+        ? users
+        : users.filter((u) => String(u.tenantId ?? '') === String(tenantId));
+    },
+
     updateMe(userId: number | string, data: UpdateMeInput) {
       return userRepo.updateMe(userId, data);
     },

--- a/src/modules/user/user.types.ts
+++ b/src/modules/user/user.types.ts
@@ -5,6 +5,8 @@ export type UserListItem = {
   email: string;
   name: string | null;
   role: Role;
+  /** Optional tenant/organization scope for multi-tenant SaaS deployments. Absent in single-tenant apps. */
+  tenantId?: string | number | null;
   emailVerifiedAt?: Date | string | null;
   createdAt: Date | string;
   updatedAt: Date | string;
@@ -16,6 +18,7 @@ export type ListUsersQuery = {
   pageSize: number;
   role?: Role;
   search?: string;
+  tenantId?: string | number;
   sort?: `${'createdAt'|'updatedAt'|'email'|'name'}:${'asc'|'desc'}`;
 };
 
@@ -40,6 +43,7 @@ export type AdminCreateUserInput = {
   role?: Role;
   bio?: string | null;
   avatarUrl?: string | null;
+  tenantId?: string | number | null;
 };
 
 export type AdminUpdateUserInput = {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -12,4 +12,5 @@ export {
   adminUpdateUserSchema,
   listUsersQuerySchema,
   updateMeSchema,
+  userIdsBatchSchema,
 } from './modules/user/user.schemas.js';

--- a/src/utils/apiKey.ts
+++ b/src/utils/apiKey.ts
@@ -1,0 +1,37 @@
+import { createHash, randomBytes, randomUUID, timingSafeEqual } from 'node:crypto';
+import type { ApiKeyRecord, ApiKeyRepo } from '../core/ports/apiKey.repo.js';
+
+function hashKey(key: string): string {
+  return createHash('sha256').update(key).digest('hex');
+}
+
+/**
+ * Generates a new API key, stores its hash via `apiKeyRepo.create`, and
+ * returns the plaintext key. The plaintext is only ever available here —
+ * only its hash is persisted, so store this return value immediately.
+ */
+export async function issueApiKey(
+  apiKeyRepo: ApiKeyRepo,
+  input: { name?: string | null; scopes?: string[]; tenantId?: string | number | null } = {},
+): Promise<{ id: string; key: string }> {
+  const id = randomUUID();
+  const secret = randomBytes(32).toString('base64url');
+  const key = `${id}.${secret}`;
+
+  await apiKeyRepo.create({
+    id,
+    name: input.name ?? null,
+    keyHash: hashKey(key),
+    scopes: input.scopes ?? [],
+    tenantId: input.tenantId ?? null,
+  });
+
+  return { id, key };
+}
+
+/** Verifies a plaintext API key against a stored record's hash using a constant-time comparison. */
+export function verifyApiKey(key: string, record: Pick<ApiKeyRecord, 'keyHash'>): boolean {
+  const expected = Buffer.from(record.keyHash);
+  const actual = Buffer.from(hashKey(key));
+  return expected.length === actual.length && timingSafeEqual(expected, actual);
+}

--- a/src/utils/jwks.ts
+++ b/src/utils/jwks.ts
@@ -1,0 +1,26 @@
+import { createPublicKey } from "node:crypto";
+import { getJwtAlgorithm, getJwtKeyId, getJwtPublicKey } from "../config/env.js";
+
+export type Jwk = Record<string, unknown>;
+
+/**
+ * Builds a JWKS document from `JWT_PUBLIC_KEY`. Returns an empty key set
+ * when `JWT_ALG` is not `RS256` (HS256 has no public key to publish).
+ */
+export function getJwks(): { keys: Jwk[] } {
+  if (getJwtAlgorithm() !== "RS256") return { keys: [] };
+
+  const keyObject = createPublicKey(getJwtPublicKey());
+  const jwk = keyObject.export({ format: "jwk" }) as Record<string, unknown>;
+
+  return {
+    keys: [
+      {
+        ...jwk,
+        use: "sig",
+        alg: "RS256",
+        kid: getJwtKeyId(),
+      },
+    ],
+  };
+}

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -7,6 +7,7 @@ export type JwtPayload = {
   typ?: "refresh";
   jti?: string;
   fam?: string;
+  tenantId?: number | string;
 };
 
 export function signAccessToken(payload: JwtPayload): string {

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -1,5 +1,13 @@
-import jwt, { type SignOptions } from "jsonwebtoken";
-import { getJwtSecret, JWT_ACCESS_EXPIRES_IN, JWT_REFRESH_EXPIRES_IN } from "../config/env.js";
+import jwt, { type SignOptions, type VerifyOptions } from "jsonwebtoken";
+import {
+  getJwtAlgorithm,
+  getJwtKeyId,
+  getJwtPrivateKey,
+  getJwtPublicKey,
+  getJwtSecret,
+  JWT_ACCESS_EXPIRES_IN,
+  JWT_REFRESH_EXPIRES_IN,
+} from "../config/env.js";
 
 export type JwtPayload = {
   sub: number | string;
@@ -10,18 +18,31 @@ export type JwtPayload = {
   tenantId?: number | string;
 };
 
+function getSigningKey(): string {
+  return getJwtAlgorithm() === "RS256" ? getJwtPrivateKey() : getJwtSecret();
+}
+
+function getVerifyingKey(): string {
+  return getJwtAlgorithm() === "RS256" ? getJwtPublicKey() : getJwtSecret();
+}
+
+function signOptions(expiresIn: string): SignOptions {
+  const algorithm = getJwtAlgorithm();
+  return {
+    expiresIn,
+    algorithm,
+    ...(algorithm === "RS256" ? { keyid: getJwtKeyId() } : {}),
+  } as SignOptions;
+}
+
 export function signAccessToken(payload: JwtPayload): string {
-  return jwt.sign(payload, getJwtSecret(), {
-    expiresIn: JWT_ACCESS_EXPIRES_IN,
-  } as SignOptions);
+  return jwt.sign(payload, getSigningKey(), signOptions(JWT_ACCESS_EXPIRES_IN));
 }
 
 export function signRefreshToken(payload: JwtPayload): string {
-  return jwt.sign({ ...payload, typ: "refresh" }, getJwtSecret(), {
-    expiresIn: JWT_REFRESH_EXPIRES_IN,
-  } as SignOptions);
+  return jwt.sign({ ...payload, typ: "refresh" }, getSigningKey(), signOptions(JWT_REFRESH_EXPIRES_IN));
 }
 
 export function verifyToken<T = JwtPayload>(token: string): T {
-  return jwt.verify(token, getJwtSecret()) as T;
+  return jwt.verify(token, getVerifyingKey(), { algorithms: [getJwtAlgorithm()] } as VerifyOptions) as T;
 }

--- a/templates/init/prisma/schema.prisma
+++ b/templates/init/prisma/schema.prisma
@@ -94,3 +94,15 @@ enum Role {
   USER
   ADMIN
 }
+
+model ApiKey {
+  id        String    @id
+  name      String?
+  keyHash   String
+  scopes    String[]  @default([])
+  tenantId  String?
+  revokedAt DateTime?
+  createdAt DateTime  @default(now())
+
+  @@index([tenantId])
+}

--- a/templates/init/prisma/schema.prisma
+++ b/templates/init/prisma/schema.prisma
@@ -106,3 +106,11 @@ model ApiKey {
 
   @@index([tenantId])
 }
+
+model IdempotencyKey {
+  key       String    @id
+  status    Int
+  body      Json
+  expiresAt DateTime?
+  createdAt DateTime  @default(now())
+}

--- a/templates/init/prisma/schema.prisma
+++ b/templates/init/prisma/schema.prisma
@@ -13,6 +13,7 @@ model User {
   passwordHash            String
   name                    String?
   role                    Role                     @default(USER)
+  tenantId                String?
   emailVerifiedAt         DateTime?
   createdAt               DateTime                 @default(now())
   updatedAt               DateTime                 @updatedAt
@@ -21,6 +22,8 @@ model User {
   passwordResetTokens     PasswordResetToken[]
   emailVerificationTokens EmailVerificationToken[]
   oauthAccounts           OauthAccount[]
+
+  @@index([tenantId])
 }
 
 model Profile {

--- a/tests/api-key-auth.test.mjs
+++ b/tests/api-key-auth.test.mjs
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+function makeRes() {
+  const res = {};
+  res.statusCode = 200;
+  res.status = (code) => { res.statusCode = code; return res; };
+  res.json = (body) => { res.body = body; return res; };
+  return res;
+}
+
+test('issueApiKey + isApiKey: valid key authenticates and attaches req.apiKey', async () => {
+  const { makeMemoryApiKeyRepo } = await import('../dist/adapters/memory.js');
+  const { issueApiKey } = await import('../dist/utils/apiKey.js');
+  const { isApiKey } = await import('../dist/middleware/isApiKey.js');
+
+  const apiKeyRepo = makeMemoryApiKeyRepo();
+  const { key } = await issueApiKey(apiKeyRepo, { name: 'billing-service', scopes: ['users:read'] });
+
+  const req = { headers: { 'x-api-key': key } };
+  const res = makeRes();
+  let nextCalled = false;
+
+  await isApiKey(apiKeyRepo)(req, res, () => { nextCalled = true; });
+
+  assert.equal(nextCalled, true);
+  assert.equal(req.apiKey.name, 'billing-service');
+  assert.deepEqual(req.apiKey.scopes, ['users:read']);
+});
+
+test('isApiKey rejects missing, malformed, and revoked keys', async () => {
+  const { makeMemoryApiKeyRepo } = await import('../dist/adapters/memory.js');
+  const { issueApiKey } = await import('../dist/utils/apiKey.js');
+  const { isApiKey } = await import('../dist/middleware/isApiKey.js');
+
+  const apiKeyRepo = makeMemoryApiKeyRepo();
+
+  const missing = makeRes();
+  await isApiKey(apiKeyRepo)({ headers: {} }, missing, () => assert.fail('should not call next'));
+  assert.equal(missing.statusCode, 401);
+
+  const malformed = makeRes();
+  await isApiKey(apiKeyRepo)({ headers: { 'x-api-key': 'not-a-valid-key' } }, malformed, () => assert.fail('should not call next'));
+  assert.equal(malformed.statusCode, 401);
+
+  const { id, key } = await issueApiKey(apiKeyRepo, {});
+  await apiKeyRepo.revoke(id);
+  const revoked = makeRes();
+  await isApiKey(apiKeyRepo)({ headers: { 'x-api-key': key } }, revoked, () => assert.fail('should not call next'));
+  assert.equal(revoked.statusCode, 401);
+});
+
+test('isApiKey enforces requiredScopes', async () => {
+  const { makeMemoryApiKeyRepo } = await import('../dist/adapters/memory.js');
+  const { issueApiKey } = await import('../dist/utils/apiKey.js');
+  const { isApiKey } = await import('../dist/middleware/isApiKey.js');
+
+  const apiKeyRepo = makeMemoryApiKeyRepo();
+  const { key } = await issueApiKey(apiKeyRepo, { scopes: ['users:read'] });
+
+  const res = makeRes();
+  await isApiKey(apiKeyRepo, { requiredScopes: ['users:write'] })(
+    { headers: { 'x-api-key': key } },
+    res,
+    () => assert.fail('should not call next'),
+  );
+  assert.equal(res.statusCode, 403);
+});

--- a/tests/api-key-auth.test.mjs
+++ b/tests/api-key-auth.test.mjs
@@ -66,3 +66,20 @@ test('isApiKey enforces requiredScopes', async () => {
   );
   assert.equal(res.statusCode, 403);
 });
+
+test('isApiKey responds 500 instead of hanging when the repo throws', async () => {
+  const { isApiKey } = await import('../dist/middleware/isApiKey.js');
+
+  const brokenRepo = {
+    async findById() { throw new Error('REPO_DOWN'); },
+    async create() {},
+    async revoke() {},
+  };
+  const middleware = isApiKey(brokenRepo);
+
+  const res = makeRes();
+  await middleware({ headers: { 'x-api-key': 'id.secret' } }, res, () => assert.fail('should not call next'));
+
+  assert.equal(res.statusCode, 500);
+  assert.equal(res.body.error.code, 'INTERNAL_ERROR');
+});

--- a/tests/api/auth.test.js
+++ b/tests/api/auth.test.js
@@ -34,6 +34,22 @@ describe('POST /api/auth/register', () => {
     const fields = res.body.error.details.map((d) => d.field);
     expect(fields).toEqual(expect.arrayContaining(['email', 'password']));
   });
+
+  it('ignores a client-supplied tenantId by default (anonymous self-registration cannot join a tenant)', async () => {
+    const { app } = buildApp();
+    const res = await registerUser(request, app, { tenantId: 'someone-elses-tenant' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.user.tenantId).toBeFalsy();
+  });
+
+  it('honors a client-supplied tenantId only when allowTenantIdOnRegister is enabled', async () => {
+    const { app } = buildApp({ auth: { allowTenantIdOnRegister: true } });
+    const res = await registerUser(request, app, { tenantId: 'tenant-a' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.user.tenantId).toBe('tenant-a');
+  });
 });
 
 describe('POST /api/auth/login', () => {

--- a/tests/api/auth.test.js
+++ b/tests/api/auth.test.js
@@ -1,0 +1,149 @@
+import request from 'supertest';
+import { buildApp, registerUser } from './helpers.js';
+
+describe('POST /api/auth/register', () => {
+  it('creates a USER account and returns tokens', async () => {
+    const { app } = buildApp();
+    const res = await registerUser(request, app);
+
+    expect(res.status).toBe(201);
+    expect(res.body.user.email).toBe('reader@example.com');
+    expect(res.body.user.role).toBe('USER');
+    expect(typeof res.body.accessToken).toBe('string');
+    expect(typeof res.body.refreshToken).toBe('string');
+    expect(res.body.user).not.toHaveProperty('passwordHash');
+  });
+
+  it('rejects a duplicate email with 409 EMAIL_ALREADY_EXISTS', async () => {
+    const { app } = buildApp();
+    await registerUser(request, app);
+    const res = await registerUser(request, app);
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe('EMAIL_ALREADY_EXISTS');
+  });
+
+  it('rejects invalid input with 400 and field-level details', async () => {
+    const { app } = buildApp();
+    const res = await request(app)
+      .post('/api/auth/register')
+      .send({ email: 'not-an-email', password: '123' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+    const fields = res.body.error.details.map((d) => d.field);
+    expect(fields).toEqual(expect.arrayContaining(['email', 'password']));
+  });
+});
+
+describe('POST /api/auth/login', () => {
+  it('logs in with correct credentials', async () => {
+    const { app } = buildApp();
+    await registerUser(request, app);
+
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'reader@example.com', password: 'password123' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.user.email).toBe('reader@example.com');
+    expect(typeof res.body.accessToken).toBe('string');
+  });
+
+  it('rejects wrong password with 401 INVALID_CREDENTIALS', async () => {
+    const { app } = buildApp();
+    await registerUser(request, app);
+
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'reader@example.com', password: 'wrong-password' });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('INVALID_CREDENTIALS');
+  });
+
+  it('rejects an unknown email with 401 INVALID_CREDENTIALS (no user enumeration)', async () => {
+    const { app } = buildApp();
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'nobody@example.com', password: 'password123' });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('INVALID_CREDENTIALS');
+  });
+});
+
+describe('POST /api/auth/refresh', () => {
+  it('issues a new token pair for a valid refresh token', async () => {
+    const { app } = buildApp();
+    const { body: registered } = await registerUser(request, app);
+
+    const res = await request(app).post('/api/auth/refresh').send({ refreshToken: registered.refreshToken });
+
+    expect(res.status).toBe(200);
+    expect(typeof res.body.accessToken).toBe('string');
+    expect(typeof res.body.refreshToken).toBe('string');
+  });
+
+  it('rejects an invalid refresh token with 401', async () => {
+    const { app } = buildApp();
+    const res = await request(app).post('/api/auth/refresh').send({ refreshToken: 'not-a-real-token' });
+    expect(res.status).toBe(401);
+  });
+
+  it('requires a refreshToken in the body', async () => {
+    const { app } = buildApp();
+    const res = await request(app).post('/api/auth/refresh').send({});
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /api/auth/logout', () => {
+  it('revokes a refresh token and responds 204', async () => {
+    const { app } = buildApp();
+    const { body: registered } = await registerUser(request, app);
+
+    const res = await request(app).post('/api/auth/logout').send({ refreshToken: registered.refreshToken });
+    expect(res.status).toBe(204);
+  });
+});
+
+describe('GET /api/auth/me', () => {
+  it('returns the authenticated user with a valid access token', async () => {
+    const { app } = buildApp();
+    const { body: registered } = await registerUser(request, app);
+
+    const res = await request(app).get('/api/auth/me').set('Authorization', `Bearer ${registered.accessToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.email).toBe('reader@example.com');
+  });
+
+  it('rejects a missing Authorization header with 401', async () => {
+    const { app } = buildApp();
+    const res = await request(app).get('/api/auth/me');
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects a malformed access token with 401', async () => {
+    const { app } = buildApp();
+    const res = await request(app).get('/api/auth/me').set('Authorization', 'Bearer not-a-real-token');
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('password reset and email verification when not configured', () => {
+  it('POST /api/auth/password-reset/request responds 501 NOT_CONFIGURED', async () => {
+    const { app } = buildApp();
+    const res = await request(app).post('/api/auth/password-reset/request').send({ email: 'reader@example.com' });
+    expect(res.status).toBe(501);
+    expect(res.body.error.code).toBe('NOT_CONFIGURED');
+  });
+
+  it('POST /api/auth/email-verification/request responds 501 NOT_CONFIGURED', async () => {
+    const { app } = buildApp();
+    const res = await request(app).post('/api/auth/email-verification/request').send({ email: 'reader@example.com' });
+    expect(res.status).toBe(501);
+    expect(res.body.error.code).toBe('NOT_CONFIGURED');
+  });
+});

--- a/tests/api/helpers.js
+++ b/tests/api/helpers.js
@@ -1,0 +1,29 @@
+import { createLibrary, createServer } from '../../dist/index.js';
+import { makeMemoryUserRepo } from '../../dist/adapters/memory.js';
+
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-secret-for-jest-api-suite';
+
+/** Builds a fresh Express app + in-memory UserRepo for a single test, so state never leaks across tests. */
+export function buildApp(config = {}) {
+  const userRepo = makeMemoryUserRepo();
+  const app = createServer();
+  const lib = createLibrary({ routesPrefix: '/api', ...config }, { userRepo });
+  app.use(lib.router);
+  return { app, userRepo };
+}
+
+/** Registers a user and returns the register response body, including tokens. */
+export async function registerUser(request, app, overrides = {}) {
+  const res = await request(app)
+    .post('/api/auth/register')
+    .send({ email: 'reader@example.com', password: 'password123', name: 'Reader', ...overrides });
+  return res;
+}
+
+/** Registers an admin directly via the repo (self-registration always creates USER accounts) and returns a login response with tokens. */
+export async function loginAsAdmin(request, app, userRepo) {
+  const bcrypt = (await import('bcryptjs')).default;
+  const passwordHash = await bcrypt.hash('adminpass123', 4);
+  await userRepo.create({ email: 'admin@example.com', passwordHash, name: 'Admin', role: 'ADMIN' });
+  return request(app).post('/api/auth/login').send({ email: 'admin@example.com', password: 'adminpass123' });
+}

--- a/tests/api/users.test.js
+++ b/tests/api/users.test.js
@@ -1,0 +1,196 @@
+import request from 'supertest';
+import { buildApp, registerUser, loginAsAdmin } from './helpers.js';
+
+describe('GET/PUT /api/users/me', () => {
+  it('returns and updates the authenticated user profile', async () => {
+    const { app } = buildApp();
+    const { body: registered } = await registerUser(request, app);
+    const auth = `Bearer ${registered.accessToken}`;
+
+    const getRes = await request(app).get('/api/users/me').set('Authorization', auth);
+    expect(getRes.status).toBe(200);
+    expect(getRes.body.email).toBe('reader@example.com');
+
+    const putRes = await request(app).put('/api/users/me').set('Authorization', auth).send({ name: 'New Name' });
+    expect(putRes.status).toBe(200);
+    expect(putRes.body.name).toBe('New Name');
+  });
+
+  it('rejects unauthenticated requests with 401', async () => {
+    const { app } = buildApp();
+    const res = await request(app).get('/api/users/me');
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /api/users (admin list)', () => {
+  it('rejects a non-admin user with 403', async () => {
+    const { app } = buildApp();
+    const { body: registered } = await registerUser(request, app);
+
+    const res = await request(app).get('/api/users').set('Authorization', `Bearer ${registered.accessToken}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('lists users for an admin', async () => {
+    const { app, userRepo } = buildApp();
+    await registerUser(request, app);
+    const { body: admin } = await loginAsAdmin(request, app, userRepo);
+
+    const res = await request(app).get('/api/users').set('Authorization', `Bearer ${admin.accessToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.total).toBeGreaterThanOrEqual(2);
+    expect(Array.isArray(res.body.items)).toBe(true);
+  });
+});
+
+describe('POST /api/users (admin create)', () => {
+  it('creates a user as an admin', async () => {
+    const { app, userRepo } = buildApp();
+    const { body: admin } = await loginAsAdmin(request, app, userRepo);
+
+    const res = await request(app)
+      .post('/api/users')
+      .set('Authorization', `Bearer ${admin.accessToken}`)
+      .send({ email: 'created@example.com', password: 'password123', role: 'USER' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.email).toBe('created@example.com');
+  });
+
+  it('rejects a non-admin with 403', async () => {
+    const { app } = buildApp();
+    const { body: registered } = await registerUser(request, app);
+
+    const res = await request(app)
+      .post('/api/users')
+      .set('Authorization', `Bearer ${registered.accessToken}`)
+      .send({ email: 'nope@example.com', password: 'password123' });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects a duplicate email with 409', async () => {
+    const { app, userRepo } = buildApp();
+    const { body: admin } = await loginAsAdmin(request, app, userRepo);
+
+    await request(app)
+      .post('/api/users')
+      .set('Authorization', `Bearer ${admin.accessToken}`)
+      .send({ email: 'dup@example.com', password: 'password123' });
+
+    const res = await request(app)
+      .post('/api/users')
+      .set('Authorization', `Bearer ${admin.accessToken}`)
+      .send({ email: 'dup@example.com', password: 'password123' });
+
+    expect(res.status).toBe(409);
+  });
+});
+
+describe('GET/PUT/DELETE /api/users/:id', () => {
+  it('allows a user to read their own record via /:id', async () => {
+    const { app } = buildApp();
+    const { body: registered } = await registerUser(request, app);
+
+    const res = await request(app)
+      .get(`/api/users/${registered.user.id}`)
+      .set('Authorization', `Bearer ${registered.accessToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.email).toBe('reader@example.com');
+  });
+
+  it('rejects a user reading another user record with 403', async () => {
+    const { app, userRepo } = buildApp();
+    const { body: reader } = await registerUser(request, app);
+    const { body: other } = await registerUser(request, app, { email: 'other@example.com' });
+    void userRepo;
+
+    const res = await request(app)
+      .get(`/api/users/${other.user.id}`)
+      .set('Authorization', `Bearer ${reader.accessToken}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  it('allows an admin to update another user, including role', async () => {
+    const { app, userRepo } = buildApp();
+    const { body: registered } = await registerUser(request, app);
+    const { body: admin } = await loginAsAdmin(request, app, userRepo);
+
+    const res = await request(app)
+      .put(`/api/users/${registered.user.id}`)
+      .set('Authorization', `Bearer ${admin.accessToken}`)
+      .send({ role: 'ADMIN' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.role).toBe('ADMIN');
+  });
+
+  it('rejects a non-admin trying to change their own role with 403', async () => {
+    const { app } = buildApp();
+    const { body: registered } = await registerUser(request, app);
+
+    const res = await request(app)
+      .put(`/api/users/${registered.user.id}`)
+      .set('Authorization', `Bearer ${registered.accessToken}`)
+      .send({ role: 'ADMIN' });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 for a missing user id', async () => {
+    const { app, userRepo } = buildApp();
+    const { body: admin } = await loginAsAdmin(request, app, userRepo);
+
+    const res = await request(app).get('/api/users/999999').set('Authorization', `Bearer ${admin.accessToken}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('allows an admin to delete a user', async () => {
+    const { app, userRepo } = buildApp();
+    const { body: registered } = await registerUser(request, app);
+    const { body: admin } = await loginAsAdmin(request, app, userRepo);
+
+    const res = await request(app)
+      .delete(`/api/users/${registered.user.id}`)
+      .set('Authorization', `Bearer ${admin.accessToken}`);
+    expect(res.status).toBe(204);
+
+    const followUp = await request(app)
+      .get(`/api/users/${registered.user.id}`)
+      .set('Authorization', `Bearer ${admin.accessToken}`);
+    expect(followUp.status).toBe(404);
+  });
+});
+
+describe('POST /api/users/batch', () => {
+  it('resolves multiple users in one call for an admin', async () => {
+    const { app, userRepo } = buildApp();
+    const { body: a } = await registerUser(request, app, { email: 'a@example.com' });
+    const { body: b } = await registerUser(request, app, { email: 'b@example.com' });
+    const { body: admin } = await loginAsAdmin(request, app, userRepo);
+
+    const res = await request(app)
+      .post('/api/users/batch')
+      .set('Authorization', `Bearer ${admin.accessToken}`)
+      .send({ ids: [a.user.id, b.user.id, 999999] });
+
+    expect(res.status).toBe(200);
+    const emails = res.body.items.map((u) => u.email).sort();
+    expect(emails).toEqual(['a@example.com', 'b@example.com']);
+  });
+
+  it('rejects a non-admin with 403', async () => {
+    const { app } = buildApp();
+    const { body: registered } = await registerUser(request, app);
+
+    const res = await request(app)
+      .post('/api/users/batch')
+      .set('Authorization', `Bearer ${registered.accessToken}`)
+      .send({ ids: [registered.user.id] });
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/tests/bulk-lookup.test.mjs
+++ b/tests/bulk-lookup.test.mjs
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+test('userRepo.findManyByIds resolves multiple users in one call, skipping unmatched ids', async () => {
+  const { makeMemoryUserRepo } = await import('../dist/adapters/memory.js');
+
+  const repo = makeMemoryUserRepo();
+  const a = await repo.create({ email: 'a@example.com', passwordHash: 'x' });
+  const b = await repo.create({ email: 'b@example.com', passwordHash: 'x' });
+  await repo.create({ email: 'c@example.com', passwordHash: 'x' });
+
+  const found = await repo.findManyByIds([a.id, b.id, 9999]);
+  const emails = found.map((u) => u.email).sort();
+  assert.deepEqual(emails, ['a@example.com', 'b@example.com']);
+});
+
+test('userService.getUsersByIds falls back to N findById calls when findManyByIds is absent', async () => {
+  const { makeUserService } = await import('../dist/modules/user/user.service.js');
+
+  const store = new Map();
+  let findManyByIdsCalls = 0;
+  const userRepo = {
+    async findById(id) {
+      return store.get(String(id)) ?? null;
+    },
+    // findManyByIds intentionally omitted
+  };
+
+  store.set('1', { id: 1, email: 'a@example.com', name: null, role: 'USER', createdAt: '', updatedAt: '' });
+  store.set('2', { id: 2, email: 'b@example.com', name: null, role: 'USER', createdAt: '', updatedAt: '' });
+
+  const service = makeUserService({ userRepo });
+  const result = await service.getUsersByIds([1, 2, 3]);
+
+  assert.equal(findManyByIdsCalls, 0);
+  assert.equal(result.length, 2);
+  assert.deepEqual(result.map((u) => u.email).sort(), ['a@example.com', 'b@example.com']);
+});
+
+test('userService.getUsersByIds scopes results to tenantId when provided', async () => {
+  const { makeMemoryUserRepo } = await import('../dist/adapters/memory.js');
+  const { makeUserService } = await import('../dist/modules/user/user.service.js');
+
+  const userRepo = makeMemoryUserRepo();
+  const a = await userRepo.create({ email: 'a@tenant-a.com', passwordHash: 'x', tenantId: 'tenant-a' });
+  const b = await userRepo.create({ email: 'b@tenant-b.com', passwordHash: 'x', tenantId: 'tenant-b' });
+
+  const service = makeUserService({ userRepo });
+  const result = await service.getUsersByIds([a.id, b.id], 'tenant-a');
+
+  assert.equal(result.length, 1);
+  assert.equal(result[0].email, 'a@tenant-a.com');
+});

--- a/tests/health.test.mjs
+++ b/tests/health.test.mjs
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import http from 'node:http';
+
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-secret-for-health-test';
+
+async function requestJson(server, path) {
+  const { port } = server.address();
+  return new Promise((resolve, reject) => {
+    http.get(`http://127.0.0.1:${port}${path}`, (res) => {
+      let data = '';
+      res.on('data', (chunk) => { data += chunk; });
+      res.on('end', () => resolve({ status: res.statusCode, body: JSON.parse(data) }));
+    }).on('error', reject);
+  });
+}
+
+async function requestStatus(server, path) {
+  const { port } = server.address();
+  return new Promise((resolve, reject) => {
+    http.get(`http://127.0.0.1:${port}${path}`, (res) => {
+      res.resume();
+      res.on('end', () => resolve(res.statusCode));
+    }).on('error', reject);
+  });
+}
+
+test('GET /health always returns 200 and GET /ready reflects userRepo health', async () => {
+  const { createLibrary, createServer } = await import('../dist/index.js');
+  const { makeMemoryUserRepo } = await import('../dist/adapters/memory.js');
+
+  const app = createServer();
+  const lib = createLibrary({}, { userRepo: makeMemoryUserRepo() });
+  app.use(lib.router);
+
+  const server = app.listen(0);
+  try {
+    await new Promise((resolve) => server.once('listening', resolve));
+
+    const health = await requestJson(server, '/health');
+    assert.equal(health.status, 200);
+    assert.equal(health.body.status, 'ok');
+
+    const ready = await requestJson(server, '/ready');
+    assert.equal(ready.status, 200);
+    assert.equal(ready.body.status, 'ok');
+  } finally {
+    server.close();
+  }
+});
+
+test('GET /ready returns 503 when userRepo.count throws', async () => {
+  const { createLibrary, createServer } = await import('../dist/index.js');
+
+  const brokenUserRepo = {
+    async count() { throw new Error('DB_DOWN'); },
+    async findMany() { return []; },
+    async findById() { return null; },
+    async findByEmail() { return null; },
+    async create(input) { return { id: 1, ...input }; },
+    async update(_id, input) { return { id: 1, ...input }; },
+    async delete() {},
+    async updateMe(_id, input) { return { id: 1, ...input }; },
+  };
+
+  const app = createServer();
+  const lib = createLibrary({}, { userRepo: brokenUserRepo });
+  app.use(lib.router);
+
+  const server = app.listen(0);
+  try {
+    await new Promise((resolve) => server.once('listening', resolve));
+    const ready = await requestJson(server, '/ready');
+    assert.equal(ready.status, 503);
+    assert.equal(ready.body.status, 'error');
+  } finally {
+    server.close();
+  }
+});
+
+test('config.health = false disables the health routes', async () => {
+  const { createLibrary, createServer } = await import('../dist/index.js');
+  const { makeMemoryUserRepo } = await import('../dist/adapters/memory.js');
+
+  const app = createServer();
+  const lib = createLibrary({ health: false }, { userRepo: makeMemoryUserRepo() });
+  app.use(lib.router);
+
+  const server = app.listen(0);
+  try {
+    await new Promise((resolve) => server.once('listening', resolve));
+    const status = await requestStatus(server, '/health');
+    assert.equal(status, 404);
+  } finally {
+    server.close();
+  }
+});

--- a/tests/idempotency.test.mjs
+++ b/tests/idempotency.test.mjs
@@ -72,3 +72,19 @@ test('memory idempotency store expires records after ttlMs', async () => {
   const afterExpiry = await store.get('short-lived');
   assert.equal(afterExpiry, null);
 });
+
+test('idempotent middleware responds 500 instead of hanging when the store throws', async () => {
+  const { idempotent } = await import('../dist/middleware/idempotent.js');
+
+  const brokenStore = {
+    async get() { throw new Error('STORE_DOWN'); },
+    async set() {},
+  };
+  const middleware = idempotent(brokenStore);
+
+  const res = makeRes();
+  await middleware({ headers: { 'idempotency-key': 'k1' } }, res, () => assert.fail('should not call next'));
+
+  assert.equal(res.statusCode, 500);
+  assert.equal(res.body.error.code, 'INTERNAL_ERROR');
+});

--- a/tests/idempotency.test.mjs
+++ b/tests/idempotency.test.mjs
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+function makeRes() {
+  const res = {};
+  res.statusCode = 200;
+  res.headers = {};
+  res.status = (code) => { res.statusCode = code; return res; };
+  res.setHeader = (name, value) => { res.headers[name] = value; };
+  res.json = (body) => { res.body = body; return res; };
+  return res;
+}
+
+test('idempotent middleware replays the stored response for a repeated key without re-running the handler', async () => {
+  const { makeMemoryIdempotencyStore } = await import('../dist/adapters/memory.js');
+  const { idempotent } = await import('../dist/middleware/idempotent.js');
+
+  const store = makeMemoryIdempotencyStore();
+  const middleware = idempotent(store);
+
+  let handlerCalls = 0;
+  const handler = (req, res) => {
+    handlerCalls += 1;
+    res.status(201).json({ id: handlerCalls });
+  };
+
+  const req = { headers: { 'idempotency-key': 'key-1' } };
+
+  const res1 = makeRes();
+  await middleware(req, res1, () => handler(req, res1));
+  assert.equal(handlerCalls, 1);
+  assert.deepEqual(res1.body, { id: 1 });
+
+  // Give the fire-and-forget store.set a tick to complete before replaying.
+  await new Promise((resolve) => setImmediate(resolve));
+
+  const res2 = makeRes();
+  await middleware(req, res2, () => handler(req, res2));
+  assert.equal(handlerCalls, 1, 'handler must not run again for a repeated idempotency key');
+  assert.deepEqual(res2.body, { id: 1 });
+  assert.equal(res2.statusCode, 201);
+  assert.equal(res2.headers['Idempotent-Replay'], 'true');
+});
+
+test('idempotent middleware passes through requests without the header', async () => {
+  const { makeMemoryIdempotencyStore } = await import('../dist/adapters/memory.js');
+  const { idempotent } = await import('../dist/middleware/idempotent.js');
+
+  const store = makeMemoryIdempotencyStore();
+  const middleware = idempotent(store);
+
+  let handlerCalls = 0;
+  const req = { headers: {} };
+  const res = makeRes();
+
+  await middleware(req, res, () => { handlerCalls += 1; res.status(200).json({ ok: true }); });
+  await middleware(req, res, () => { handlerCalls += 1; res.status(200).json({ ok: true }); });
+
+  assert.equal(handlerCalls, 2, 'handler runs every time when no idempotency key is sent');
+});
+
+test('memory idempotency store expires records after ttlMs', async () => {
+  const { makeMemoryIdempotencyStore } = await import('../dist/adapters/memory.js');
+
+  const store = makeMemoryIdempotencyStore();
+  await store.set('short-lived', { status: 200, body: { ok: true } }, 10);
+
+  const immediate = await store.get('short-lived');
+  assert.ok(immediate);
+
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  const afterExpiry = await store.get('short-lived');
+  assert.equal(afterExpiry, null);
+});

--- a/tests/jwks.test.mjs
+++ b/tests/jwks.test.mjs
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { generateKeyPairSync, createPublicKey } from 'node:crypto';
+
+test('RS256: tokens signed with the private key verify against the public key, and JWKS matches', async () => {
+  const { publicKey, privateKey } = generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+
+  process.env.JWT_ALG = 'RS256';
+  process.env.JWT_PRIVATE_KEY = privateKey;
+  process.env.JWT_PUBLIC_KEY = publicKey;
+  process.env.JWT_KEY_ID = 'test-key-1';
+
+  try {
+    const { signAccessToken, verifyToken } = await import('../dist/utils/jwt.js');
+    const { getJwks } = await import('../dist/utils/jwks.js');
+
+    const token = signAccessToken({ sub: 42, role: 'USER' });
+    const payload = verifyToken(token);
+    assert.equal(payload.sub, 42);
+    assert.equal(payload.role, 'USER');
+
+    const jwks = getJwks();
+    assert.equal(jwks.keys.length, 1);
+    assert.equal(jwks.keys[0].kid, 'test-key-1');
+    assert.equal(jwks.keys[0].kty, 'RSA');
+
+    // Confirm the published JWK actually matches the signing key's modulus/exponent.
+    const expectedJwk = createPublicKey(publicKey).export({ format: 'jwk' });
+    assert.equal(jwks.keys[0].n, expectedJwk.n);
+    assert.equal(jwks.keys[0].e, expectedJwk.e);
+  } finally {
+    delete process.env.JWT_ALG;
+    delete process.env.JWT_PRIVATE_KEY;
+    delete process.env.JWT_PUBLIC_KEY;
+    delete process.env.JWT_KEY_ID;
+  }
+});
+
+test('JWKS is empty when JWT_ALG is not RS256', async () => {
+  delete process.env.JWT_ALG;
+  const { getJwks } = await import('../dist/utils/jwks.js');
+  assert.deepEqual(getJwks(), { keys: [] });
+});

--- a/tests/multi-tenancy.test.mjs
+++ b/tests/multi-tenancy.test.mjs
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-secret-for-multi-tenancy-test';
+
+test('tenantId flows from registration through tokens and scoped listing', async () => {
+  const { makeAuthService } = await import('../dist/modules/auth/auth.service.js');
+  const { makeMemoryUserRepo } = await import('../dist/adapters/memory.js');
+  const { verifyToken } = await import('../dist/utils/jwt.js');
+
+  const userRepo = makeMemoryUserRepo();
+  const service = makeAuthService({ userRepo, passwordHashRounds: 4 });
+
+  const tenantA = await service.registerUser({ email: 'a@tenant-a.com', password: 'password123', tenantId: 'tenant-a' });
+  await service.registerUser({ email: 'b@tenant-b.com', password: 'password123', tenantId: 'tenant-b' });
+
+  assert.equal(tenantA.user.tenantId, 'tenant-a');
+
+  const payload = verifyToken(tenantA.accessToken);
+  assert.equal(payload.tenantId, 'tenant-a');
+
+  const onlyTenantA = await userRepo.findMany({
+    page: 1,
+    pageSize: 10,
+    tenantId: 'tenant-a',
+    sortField: 'createdAt',
+    sortDir: 'asc',
+  });
+  assert.equal(onlyTenantA.length, 1);
+  assert.equal(onlyTenantA[0].email, 'a@tenant-a.com');
+
+  const countTenantB = await userRepo.count({ tenantId: 'tenant-b' });
+  assert.equal(countTenantB, 1);
+});
+
+test('isSameTenant middleware rejects cross-tenant access', async () => {
+  const { isSameTenant, requireTenant } = await import('../dist/middleware/tenant.js');
+
+  const makeRes = () => {
+    const res = {};
+    res.statusCode = 200;
+    res.status = (code) => { res.statusCode = code; return res; };
+    res.json = (body) => { res.body = body; return res; };
+    return res;
+  };
+
+  const mismatch = { user: { id: 1, role: 'ADMIN', tenantId: 'tenant-a' }, params: { tenantId: 'tenant-b' } };
+  const res1 = makeRes();
+  let nextCalled = false;
+  isSameTenant()(mismatch, res1, () => { nextCalled = true; });
+  assert.equal(nextCalled, false);
+  assert.equal(res1.statusCode, 403);
+
+  const match = { user: { id: 1, role: 'ADMIN', tenantId: 'tenant-a' }, params: { tenantId: 'tenant-a' } };
+  const res2 = makeRes();
+  let nextCalled2 = false;
+  isSameTenant()(match, res2, () => { nextCalled2 = true; });
+  assert.equal(nextCalled2, true);
+
+  const noTenant = { user: { id: 1, role: 'ADMIN' }, params: {} };
+  const res3 = makeRes();
+  let nextCalled3 = false;
+  requireTenant()(noTenant, res3, () => { nextCalled3 = true; });
+  assert.equal(nextCalled3, false);
+  assert.equal(res3.statusCode, 403);
+});

--- a/tests/rate-limit.test.mjs
+++ b/tests/rate-limit.test.mjs
@@ -62,3 +62,18 @@ test('rateLimit middleware blocks with 429 and Retry-After once the limiter deni
   assert.equal(res2.statusCode, 429);
   assert.ok(res2.headers['Retry-After']);
 });
+
+test('rateLimit middleware responds 500 instead of hanging when the limiter throws', async () => {
+  const { rateLimit } = await import('../dist/middleware/rateLimit.js');
+
+  const brokenLimiter = {
+    async consume() { throw new Error('LIMITER_DOWN'); },
+  };
+  const middleware = rateLimit(brokenLimiter);
+
+  const res = makeRes();
+  await middleware({ ip: '127.0.0.1' }, res, () => assert.fail('should not call next'));
+
+  assert.equal(res.statusCode, 500);
+  assert.equal(res.body.error.code, 'INTERNAL_ERROR');
+});

--- a/tests/rate-limit.test.mjs
+++ b/tests/rate-limit.test.mjs
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+function makeRes() {
+  const res = {};
+  res.statusCode = 200;
+  res.headers = {};
+  res.status = (code) => { res.statusCode = code; return res; };
+  res.setHeader = (name, value) => { res.headers[name] = value; };
+  res.json = (body) => { res.body = body; return res; };
+  return res;
+}
+
+test('makeMemoryRateLimiter allows up to `points` requests then blocks within the window', async () => {
+  const { makeMemoryRateLimiter } = await import('../dist/adapters/memory.js');
+
+  const limiter = makeMemoryRateLimiter({ points: 3, durationMs: 60_000 });
+
+  const first = await limiter.consume('client-a');
+  const second = await limiter.consume('client-a');
+  const third = await limiter.consume('client-a');
+  const fourth = await limiter.consume('client-a');
+
+  assert.equal(first.allowed, true);
+  assert.equal(second.allowed, true);
+  assert.equal(third.allowed, true);
+  assert.equal(fourth.allowed, false);
+  assert.ok(fourth.retryAfterMs > 0);
+});
+
+test('makeMemoryRateLimiter tracks separate keys independently', async () => {
+  const { makeMemoryRateLimiter } = await import('../dist/adapters/memory.js');
+
+  const limiter = makeMemoryRateLimiter({ points: 1, durationMs: 60_000 });
+
+  const a1 = await limiter.consume('client-a');
+  const b1 = await limiter.consume('client-b');
+  const a2 = await limiter.consume('client-a');
+
+  assert.equal(a1.allowed, true);
+  assert.equal(b1.allowed, true);
+  assert.equal(a2.allowed, false);
+});
+
+test('rateLimit middleware blocks with 429 and Retry-After once the limiter denies', async () => {
+  const { makeMemoryRateLimiter } = await import('../dist/adapters/memory.js');
+  const { rateLimit } = await import('../dist/middleware/rateLimit.js');
+
+  const limiter = makeMemoryRateLimiter({ points: 1, durationMs: 60_000 });
+  const middleware = rateLimit(limiter, { keyFn: () => 'fixed-key' });
+
+  const req = { ip: '127.0.0.1' };
+
+  const res1 = makeRes();
+  let nextCalls = 0;
+  await middleware(req, res1, () => { nextCalls += 1; });
+  assert.equal(nextCalls, 1);
+
+  const res2 = makeRes();
+  await middleware(req, res2, () => { nextCalls += 1; });
+  assert.equal(nextCalls, 1, 'next must not be called once the limit is exceeded');
+  assert.equal(res2.statusCode, 429);
+  assert.ok(res2.headers['Retry-After']);
+});

--- a/tests/request-id.test.mjs
+++ b/tests/request-id.test.mjs
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+function makeRes() {
+  const res = {};
+  res.headers = {};
+  res.setHeader = (name, value) => { res.headers[name] = value; };
+  return res;
+}
+
+test('requestId generates an id and reflects it in the response header when none is sent', async () => {
+  const { requestId } = await import('../dist/middleware/requestId.js');
+
+  const req = { headers: {} };
+  const res = makeRes();
+  let nextCalled = false;
+
+  requestId()(req, res, () => { nextCalled = true; });
+
+  assert.equal(nextCalled, true);
+  assert.equal(typeof req.id, 'string');
+  assert.ok(req.id.length > 0);
+  assert.equal(res.headers['X-Request-Id'], req.id);
+});
+
+test('requestId reuses an incoming X-Request-Id header instead of generating a new one', async () => {
+  const { requestId } = await import('../dist/middleware/requestId.js');
+
+  const req = { headers: { 'x-request-id': 'incoming-id-123' } };
+  const res = makeRes();
+
+  requestId()(req, res, () => {});
+
+  assert.equal(req.id, 'incoming-id-123');
+  assert.equal(res.headers['X-Request-Id'], 'incoming-id-123');
+});
+
+test('requestId supports a custom header name', async () => {
+  const { requestId } = await import('../dist/middleware/requestId.js');
+
+  const req = { headers: { 'x-correlation-id': 'corr-1' } };
+  const res = makeRes();
+
+  requestId({ headerName: 'X-Correlation-Id' })(req, res, () => {});
+
+  assert.equal(req.id, 'corr-1');
+});


### PR DESCRIPTION
## Version: 3.1.0

Bundles 9 SaaS/microservices issues (#32-#40), each merged individually into `develop` via PR #41-#49, plus a follow-up review-fix PR (#50).

## Summary

- **#32** — Multi-tenancy: optional `tenantId` on `UserRepo`/JWT, auto-scoped admin routes, `requireTenant()`/`isSameTenant()` middleware.
- **#33** — Machine-to-machine API key auth: `ApiKeyRepo` port, `issueApiKey`/`verifyApiKey`, `isApiKey` middleware.
- **#34** — Optional RS256/JWKS: sign with a private key, verify via a public key or `GET /.well-known/jwks.json` — no shared secret needed across services.
- **#35** — Idempotency keys: `IdempotencyStore` port + `idempotent` middleware on `POST /auth/register` and admin `POST /users`.
- **#36** — Bulk user lookup: optional `UserRepo.findManyByIds` + `POST /users/batch`.
- **#37** — Pluggable rate limiter on login/register.
- **#38** — Correlation id / request tracing (`requestId`, mounted by default in `createServer()`).
- **#39** — Health check endpoints (`GET /health`, `GET /ready`), mounted by default.
- **#40** — Jest + Supertest end-to-end API suite, running in CI on every PR.

## Review fixes (PR #50)

A full review of `develop` before this PR caught and fixed 4 issues:
1. `idempotent`/`rateLimit`/`isApiKey` middleware could leave a request hanging (no response) if their backing store threw — now they respond with a proper error.
2. `POST /auth/register` accepted an unauthenticated, client-supplied `tenantId` — now ignored by default, opt-in via `allowTenantIdOnRegister`.
3. `makePrismaIdempotencyStore` never deleted expired rows — now evicts on read.
4. Version/changelog hadn't been bumped for this batch.

## Breaking Changes

None beyond what 3.0.0 already introduced. Every feature in this release is additive and opt-in (new optional deps/config), except the `tenantId`-on-register default change, which tightens an unsafe default rather than breaking a legitimate use case (self-registration is unauthenticated, so nothing should have relied on it accepting an arbitrary tenant id).

## Test plan
- [x] `npm run build`
- [x] `npm test` (45/45 `node:test`)
- [x] `npm run test:api` (32/32 Jest + Supertest)
- [x] `npm run ci` (full checklist incl. `npm pack --dry-run`)
- [x] `package.json`/`package-lock.json` bumped to `3.1.0`, `CHANGELOG.md` updated

## Not done here
No publish/deploy performed in this PR — only prepares the release. After merge, follow `RELEASE.md` to publish to npm.